### PR TITLE
docs(storybook): update List stories and translate Korean copy

### DIFF
--- a/apps/docs/src/stories/Card.stories.tsx
+++ b/apps/docs/src/stories/Card.stories.tsx
@@ -125,7 +125,7 @@ export const WithTitle: Story = {
             id: 'card-1',
             type: 'Card',
             state: {
-              title: '학습 가이드',
+              title: 'Learning Guide',
             },
             attributes: {},
             children: [
@@ -194,7 +194,7 @@ export const WithListItems: Story = {
             id: 'card-1',
             type: 'Card',
             state: {
-              title: '학습 가이드',
+              title: 'Learning Guide',
             },
             attributes: {},
             children: [
@@ -241,7 +241,7 @@ export const WithListItems: Story = {
                             id: 'list-1-title',
                             type: 'Span',
                             state: {
-                              text: '1. 기사 읽기',
+                              text: '1. Read an Article',
                             },
                             attributes: {
                               className: 'text-base font-semibold text-[var(--color-text-default)]',
@@ -251,7 +251,7 @@ export const WithListItems: Story = {
                             id: 'list-1-description',
                             type: 'Span',
                             state: {
-                              text: '오늘의 추천 기사를 읽고 단어를 저장하세요',
+                              text: "Read today's featured article and save new words",
                             },
                             attributes: {
                               className: 'text-sm text-[var(--color-text-subtle)]',

--- a/apps/docs/src/stories/Colors.css
+++ b/apps/docs/src/stories/Colors.css
@@ -74,7 +74,7 @@
   color: var(--color-gray-600, #646464);
 }
 
-/* 다크 배경에서도 잘 보이도록 */
+/* Ensure visibility on dark backgrounds. */
 .color-box[data-color-value='#ffffff'] .color-box__swatch,
 .color-box[data-color-value='#f0f0f0'] .color-box__swatch,
 .color-box[data-color-value='#dcf8e9'] .color-box__swatch,

--- a/apps/docs/src/stories/Colors.tsx
+++ b/apps/docs/src/stories/Colors.tsx
@@ -52,12 +52,12 @@ interface ParsedColor {
 }
 
 /**
- * CSS 파일에서 색상 변수를 파싱합니다.
- * --color-* 형식의 변수만 추출합니다.
+ * Parses color variables from the CSS file.
+ * Extracts only variables in the --color-* format.
  */
 function parseColorsFromCss(cssText: string): ParsedColor[] {
   const colors: ParsedColor[] = []
-  // :root 또는 [data-theme='light'] 블록에서 --color-로 시작하는 변수 추출
+  // Extract variables starting with --color- from :root or [data-theme='light'] blocks.
   const colorVarRegex = /--color-([^:]+):\s*([^;]+);/g
   const seen = new Set<string>()
 
@@ -67,21 +67,21 @@ function parseColorsFromCss(cssText: string): ParsedColor[] {
     const variable = `--color-${match[1].trim()}`
     const value = match[2].trim()
 
-    // 중복 제거 (light/dark 테마에서 같은 변수가 있을 수 있음)
+    // Remove duplicates (light/dark themes can include the same variables).
     if (!seen.has(variable)) {
       seen.add(variable)
 
-      // fallback 값 추출 (var(--other-var, #color) 형식에서 #color 추출)
+      // Extract fallback value (grab #color from var(--other-var, #color) format).
       let fallbackValue = value
       const fallbackMatch = value.match(/,\s*([^)]+)\)$/)
       if (fallbackMatch) {
         fallbackValue = fallbackMatch[1].trim()
       } else if (value.startsWith('var(')) {
-        // var()만 있고 fallback이 없는 경우, 변수 이름을 그대로 사용
+        // If there is only var() and no fallback, keep the variable name as-is.
         fallbackValue = value
       }
 
-      // 변수 이름을 읽기 쉽게 변환
+      // Convert variable name into a readable label.
       const name = variable
         .replace('--color-', '')
         .replace(/-/g, ' ')
@@ -99,13 +99,13 @@ function parseColorsFromCss(cssText: string): ParsedColor[] {
 }
 
 /**
- * 색상들을 카테고리별로 그룹화합니다.
+ * Groups colors by category.
  */
 function groupColorsByCategory(colors: ParsedColor[]): Array<{ title: string; colors: ParsedColor[] }> {
   const groups: Record<string, ParsedColor[]> = {}
 
   colors.forEach((color) => {
-    // 변수 이름에서 카테고리 추출 (예: --color-background-* -> Background)
+    // Extract category from variable name (e.g., --color-background-* -> Background).
     const categoryMatch = color.variable.match(/--color-([^-]+)/)
     if (!categoryMatch) {
       return
@@ -120,10 +120,10 @@ function groupColorsByCategory(colors: ParsedColor[]): Array<{ title: string; co
     groups[categoryTitle].push(color)
   })
 
-  // 카테고리별로 정렬
+  // Sort by category.
   return Object.entries(groups)
     .sort(([a], [b]) => {
-      // 특정 순서로 정렬
+      // Sort in a specific order.
       const order = ['Background', 'Text', 'Border', 'Icon', 'Link', 'Chart', 'Interaction', 'Skeleton', 'Blanket']
       const indexA = order.indexOf(a)
       const indexB = order.indexOf(b)
@@ -157,7 +157,7 @@ export const Colors = () => {
     <div className="colors-container">
       <div style={{ marginBottom: '2rem', padding: '1rem', background: '#f5f5f5', borderRadius: '8px' }}>
         <p style={{ margin: 0, fontSize: '0.875rem', color: '#666' }}>
-          출처:{' '}
+          Source:{' '}
           <a
             href="https://www.figma.com/design/RXclnIXmr2835BdXOKBJDL/ADS-Foundations--Community-?node-id=14439-10399&p=f&t=i4NwiBe0wp852FUm-0"
             target="_blank"

--- a/apps/docs/src/stories/Div.stories.tsx
+++ b/apps/docs/src/stories/Div.stories.tsx
@@ -51,7 +51,7 @@ When used in the **SDUI template system**, the Div component:
 export default meta
 type Story = StoryObj<typeof Div>
 
-// 기본 Div 예시
+// Basic Div example
 export const Default: Story = {
   render: () => {
     const document: SduiLayoutDocument = {
@@ -67,7 +67,7 @@ export const Default: Story = {
             id: 'title',
             type: 'Span',
             state: {
-              text: '기본 Div 컴포넌트',
+              text: 'Basic Div Component',
             },
             attributes: {
               className: 'text-lg font-bold mb-4',
@@ -77,7 +77,7 @@ export const Default: Story = {
             id: 'description',
             type: 'Span',
             state: {
-              text: 'Div 컴포넌트는 Error Boundary와 Suspense를 내장하고 있습니다.',
+              text: 'The Div component includes built-in Error Boundary and Suspense.',
             },
             attributes: {
               className: 'text-gray-600 mb-4',
@@ -94,7 +94,7 @@ export const Default: Story = {
                 id: 'div-content',
                 type: 'Span',
                 state: {
-                  text: '이 div는 Error Boundary와 Suspense로 감싸져 있습니다.',
+                  text: 'This div is wrapped with Error Boundary and Suspense.',
                 },
               },
             ],
@@ -134,7 +134,7 @@ No additional configuration needed - error handling and async loading support ar
   },
 }
 
-// Nested Divs 예시
+// Nested Divs example
 export const NestedDivs: Story = {
   render: () => {
     const document: SduiLayoutDocument = {
@@ -150,7 +150,7 @@ export const NestedDivs: Story = {
             id: 'title',
             type: 'Span',
             state: {
-              text: 'Nested Divs 예시',
+              text: 'Nested Divs Example',
             },
             attributes: {
               className: 'text-lg font-bold mb-4',
@@ -237,7 +237,7 @@ export const WithCustomStyling: Story = {
             id: 'title',
             type: 'Span',
             state: {
-              text: 'Custom Styling 예시',
+              text: 'Custom Styling Example',
             },
             attributes: {
               className: 'text-lg font-bold mb-4',
@@ -309,7 +309,7 @@ export const AsContainer: Story = {
             id: 'title',
             type: 'Span',
             state: {
-              text: 'Container 예시',
+              text: 'Container Example',
             },
             attributes: {
               className: 'text-lg font-bold mb-4',

--- a/apps/docs/src/stories/Icon.stories.tsx
+++ b/apps/docs/src/stories/Icon.stories.tsx
@@ -836,7 +836,7 @@ export const SizeComparison: Story = {
             id: 'title',
             type: 'Span',
             state: {
-              text: 'Size Comparison (Tailwind Spacing Scale 기준)',
+              text: 'Size Comparison (Tailwind Spacing Scale Reference)',
             },
             attributes: {
               className: 'text-lg font-bold',

--- a/apps/docs/src/stories/List.stories.tsx
+++ b/apps/docs/src/stories/List.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable local-rules/no-console-log */
 import { type SduiLayoutDocument, SduiLayoutRenderer } from '@lodado/sdui-template'
-import { getListComponents,Icon, List } from '@lodado/sdui-template-component'
+import { getListComponents, List } from '@lodado/sdui-template-component'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import React from 'react'
 
@@ -45,7 +45,7 @@ Uses the **Compound Component pattern** to flexibly arrange:
 - ✅ **Keyboard navigation** support
 - ✅ **Accessibility features** built-in
 - ✅ **ARIA attributes** for screen readers
-- ✅ **Link support**: Can render as anchor tag
+- ✅ **SDUI metadata**: Supports nodeId/eventId data attributes
 
 ## Common Use Cases
 
@@ -114,13 +114,18 @@ const XIcon = () => (
 export const Default: Story = {
   render: () => (
     <div className="p-4">
-      <List onClick={() => console.log('Clicked')} className="w-[70vw]">
+      <List
+        onClick={() => console.log('Clicked')}
+        className="w-[70vw]"
+        nodeId="storybook-list-default"
+        eventId="storybook-list-default-click"
+      >
         <List.Icon color="blue">
           <BookIcon />
         </List.Icon>
         <List.Content>
-          <List.Title>기사 읽기</List.Title>
-          <List.Description>오늘의 추천 기사를 읽고 단어를 저장하세요</List.Description>
+          <List.Title>Read an Article</List.Title>
+          <List.Description>Read today&apos;s featured article and save new words</List.Description>
         </List.Content>
         <List.Arrow />
       </List>
@@ -145,6 +150,7 @@ The **default list configuration** demonstrates the basic compound component pat
 ## Usage
 
 This is the recommended pattern for creating interactive list items with icons, text, and navigation indicators.
+The nodeId and eventId props map to data-node-id and data-event-id attributes for SDUI metadata.
         `,
       },
     },
@@ -158,29 +164,29 @@ export const WithMultipleItems: Story = {
       {
         id: 1,
         iconColor: 'blue' as const,
-        title: '1. 기사 읽기',
-        description: '오늘의 추천 기사를 읽고 단어를 저장하세요',
+        title: '1. Read an Article',
+        description: 'Read today&apos;s featured article and save new words',
         icon: <BookIcon />,
       },
       {
         id: 2,
         iconColor: 'green' as const,
-        title: '2. 단어장 확인',
-        description: '저장한 단어들을 확인하고 관리하세요',
+        title: '2. Review Vocabulary',
+        description: 'Check and manage the words you saved',
         icon: <BooksIcon />,
       },
       {
         id: 3,
         iconColor: 'purple' as const,
-        title: '3. 퀴즈 풀기',
-        description: '퀴즈로 학습 효과를 확인하세요',
+        title: '3. Take a Quiz',
+        description: 'Use a quiz to confirm learning progress',
         icon: <TargetIcon />,
       },
       {
         id: 4,
         iconColor: 'red' as const,
-        title: '4. 오답 복습',
-        description: '틀린 문제를 다시 풀어보세요',
+        title: '4. Review Mistakes',
+        description: 'Retry the questions you missed',
         icon: <XIcon />,
       },
     ]
@@ -212,12 +218,12 @@ export const WithMultipleItems: Story = {
 
 ## Figma Design Recreation
 
-This story demonstrates the "학습 가이드" (Learning Guide) section from the Figma design:
+This story demonstrates the "Learning Guide" section from the Figma design:
 
-1. **기사 읽기** (Read Article) - Blue icon
-2. **단어장 확인** (Check Vocabulary) - Green icon
-3. **퀴즈 풀기** (Take Quiz) - Purple icon
-4. **오답 복습** (Review Incorrect Answers) - Red icon
+1. **Read an Article** - Blue icon
+2. **Review Vocabulary** - Green icon
+3. **Take a Quiz** - Purple icon
+4. **Review Mistakes** - Red icon
 
 ## Icon Colors
 


### PR DESCRIPTION
### Motivation

- Reflect recent List component updates in Storybook examples and show SDUI metadata usage via `nodeId`/`eventId` attributes.
- Standardize documentation language by translating Korean copy in the stories to English for consistency across the docs.

### Description

- Updated `apps/docs/src/stories/List.stories.tsx` to remove an unused `Icon` import, add `nodeId` and `eventId` to the default story, and translate Korean list titles/descriptions to English.
- Translated Korean strings in `apps/docs/src/stories/Card.stories.tsx` and changed card list items to English equivalents used by the List story.
- Translated multiple story strings and comments in `apps/docs/src/stories/Div.stories.tsx`, `apps/docs/src/stories/Icon.stories.tsx`, and `apps/docs/src/stories/Colors.tsx`, and updated the CSS comment in `apps/docs/src/stories/Colors.css` to English.
- Minor docs improvements: added a note in the List docs that `nodeId`/`eventId` map to `data-node-id`/`data-event-id` for SDUI metadata.

### Testing

- Ran `turbo run lint -- --cache --fix "--fix"`, which completed and reported only non-blocking warnings.
- Ran `turbo run test --concurrency=5`, and the test suites completed successfully with all automated tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bc1c047b8832ea0e481c4860bf2a9)