### PR TITLE
Remove unused asChild handling from Card

### DIFF
--- a/packages/sdui-template-component/src/shared/ui/card/Card.tsx
+++ b/packages/sdui-template-component/src/shared/ui/card/Card.tsx
@@ -1,4 +1,3 @@
-import { Slot } from '@radix-ui/react-slot'
 import React from 'react'
 
 import { cn } from '../../lib/cn'
@@ -36,7 +35,6 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>(
       nodeId,
       eventId,
       title,
-      asChild = false,
       ...props
     },
     ref,
@@ -45,22 +43,6 @@ export const Card = React.forwardRef<HTMLDivElement, CardProps>(
     const variantClasses = cardVariants()
 
     const mergedClassName = cn(variantClasses, className)
-
-    if (asChild) {
-      return (
-        <Slot
-          ref={ref}
-          className={mergedClassName}
-          data-node-id={nodeId}
-          data-event-id={eventId}
-          // eslint-disable-next-line react/jsx-props-no-spreading
-          {...props}
-        >
-          {title && <h3 className="mb-4 text-lg font-bold text-[var(--color-text-default)]">{title}</h3>}
-          {children}
-        </Slot>
-      )
-    }
 
     return (
       <div


### PR DESCRIPTION
### Motivation
- Fix a TypeScript error where `asChild` was referenced on `CardProps` even though it is not defined, by removing unused `asChild` handling and related slot usage.

### Description
- Drop the `@radix-ui/react-slot` import and remove the `asChild` prop/default and conditional rendering so `Card` always renders a `div` and uses only `CardProps` defined in `types.ts`.

### Testing
- Ran `turbo run lint -- --cache --fix "--fix"`, which completed but produced repository lint warnings (no blocking errors).
- Ran `turbo run test --concurrency=5`, which executed the test suite; tests completed with passing suites but test output included pre-existing console errors/warnings unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cb34cf8fc832ebcc1414dcf1c9467)