### PR TITLE
fix: show required indicator in TextField story

### DIFF
--- a/apps/docs/src/stories/TextField.stories.tsx
+++ b/apps/docs/src/stories/TextField.stories.tsx
@@ -761,10 +761,10 @@ export const Required: Story = {
               {
                 id: 'textfield',
                 type: 'TextField',
-                attributes: {
+                state: {
                   error: false,
-                  disabled: false,
                   required: true,
+                  disabled: false,
                 },
                 children: [
                   {


### PR DESCRIPTION
### Motivation
- The Required story passed the `required` flag in node `attributes`, but `TextFieldContainer` reads `required` from node `state`, so the label's required indicator (asterisk) was not rendered.

### Description
- Move the `required` (and related flags) for the Required story into the node `state` in `apps/docs/src/stories/TextField.stories.tsx` so the `TextField` receives the value via `TextFieldContainer` and the label shows the required indicator.

### Testing
- Ran `pnpm --filter @lodado/sdui-template-component test` and component tests passed. 
- Ran `turbo run lint -- --cache --fix` which completed (warnings only). 
- Ran `turbo run test --concurrency=5` and all monorepo test suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970b64c2214832ebc4893643d1098e7)