### PR TITLE
refactor: use refresh action constants and translate copy

### DIFF
--- a/apps/nextAuthOauthLoginExample/README.md
+++ b/apps/nextAuthOauthLoginExample/README.md
@@ -1,18 +1,18 @@
 # NextAuth OAuth Login Example (SDUI)
 
-이 앱은 NextAuth GitHub OAuth 로그인과 SDUI 템플릿/컴포넌트를 사용한 로그인 화면 예제를 제공합니다.
+This app provides a login screen example using NextAuth GitHub OAuth login with SDUI templates/components.
 
-## 주요 동작
+## Key Behaviors
 
-- **GitHub 로그인**: NextAuth를 사용해 GitHub OAuth 로그인 처리
-- **SDUI 렌더링**: `@lodado/sdui-template`, `@lodado/sdui-template-component`를 사용해 화면 구성
-- **JWT 쿠키**: 액세스 토큰(NextAuth JWT)은 httpOnly 쿠키에 저장
-- **RTR(Refresh Token Rotation)**: 리프레시 토큰은 Supabase DB에 저장하고 매 갱신 시 회전
-- **자동 갱신**: 클라이언트에서 세션이 만료되면 리프레시 토큰으로 자동 재발급 시도
+- **GitHub login**: Handle GitHub OAuth login using NextAuth
+- **SDUI rendering**: Build the UI with `@lodado/sdui-template` and `@lodado/sdui-template-component`
+- **JWT cookies**: Store access tokens (NextAuth JWT) in httpOnly cookies
+- **RTR (Refresh Token Rotation)**: Store refresh tokens in the Supabase DB and rotate on each refresh
+- **Auto refresh**: When the session expires, the client attempts re-issuance with the refresh token
 
-## 환경 변수
+## Environment Variables
 
-`.env.local`에 아래 값을 설정하세요.
+Set the following values in `.env.local`.
 
 ```
 GITHUB_CLIENT_ID=
@@ -23,11 +23,11 @@ SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
 ```
 
-## Supabase 설정
+## Supabase Setup
 
-### 1) Refresh Token 테이블 생성
+### 1) Create the Refresh Token table
 
-Supabase SQL Editor에서 아래 스크립트를 실행하세요.
+Run the following script in the Supabase SQL Editor.
 
 ```sql
 create extension if not exists "pgcrypto";
@@ -48,27 +48,27 @@ create table if not exists public.auth_refresh_tokens (
 create index if not exists auth_refresh_tokens_user_id_idx on public.auth_refresh_tokens (user_id);
 ```
 
-### 2) Storage 버킷 생성
+### 2) Create a Storage bucket
 
-Supabase Storage에서 `avatars` 버킷을 생성하세요. (public/private 여부는 정책에 맞게 설정)
+Create an `avatars` bucket in Supabase Storage. (Configure public/private according to your policy.)
 
-> 이 앱은 GitHub 프로필 이미지를 `avatars` 버킷에 업로드하도록 구현되어 있습니다.
+> This app is implemented to upload GitHub profile images to the `avatars` bucket.
 
-## 실행
+## Run
 
 ```bash
 pnpm --filter next-auth-oauth-login-example dev
 ```
 
-## 동작 흐름
+## Flow
 
-1. 로그인 성공 시 클라이언트에서 `/api/auth/refresh`를 호출해 리프레시 토큰을 발급합니다.
-2. 리프레시 토큰은 **Supabase DB**에 저장되며, 쿠키로도 저장됩니다.
-3. 세션(JWT)이 만료되면 클라이언트가 `/api/auth/refresh`를 호출해
-   리프레시 토큰을 대조하고 신규 세션 토큰을 발급합니다.
-4. 리프레시 토큰은 회전(RTR)되어 재사용이 차단됩니다.
+1. After a successful login, the client calls `/api/auth/refresh` to issue a refresh token.
+2. The refresh token is stored in the **Supabase DB** and also saved as a cookie.
+3. When the session (JWT) expires, the client calls `/api/auth/refresh`,
+   validates the refresh token, and issues a new session token.
+4. The refresh token is rotated (RTR) to prevent reuse.
 
-## 참고
+## Notes
 
-- 세션 만료 시간은 **15분**(`sessionMaxAgeSeconds`)으로 설정되어 있습니다.
-- 리프레시 토큰 만료 시간은 **30일**로 설정되어 있습니다.
+- The session expiration time is set to **15 minutes** (`sessionMaxAgeSeconds`).
+- The refresh token expiration time is set to **30 days**.

--- a/apps/nextAuthOauthLoginExample/src/app/api/auth/logout/route.ts
+++ b/apps/nextAuthOauthLoginExample/src/app/api/auth/logout/route.ts
@@ -9,18 +9,18 @@ export async function POST() {
   const cookieStore = cookies()
   const refreshToken = cookieStore.get(refreshCookieName)?.value
 
-  // 리프레시 토큰이 있으면 DB에서 revoke 처리
+  // Revoke refresh token from the database if it exists
   if (refreshToken) {
     try {
       await revokeRefreshToken(refreshToken)
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('Failed to revoke refresh token:', error)
-      // 에러가 나도 쿠키는 삭제
+      // Remove the cookie even if revocation fails
     }
   }
 
-  // 리프레시 토큰 쿠키 삭제
+  // Remove refresh token cookie
   cookieStore.set(refreshCookieName, '', {
     httpOnly: true,
     sameSite: 'lax' as const,

--- a/apps/nextAuthOauthLoginExample/src/app/components/sdui-components.tsx
+++ b/apps/nextAuthOauthLoginExample/src/app/components/sdui-components.tsx
@@ -121,7 +121,7 @@ const LoginButton: React.FC<{ nodeId: string }> = ({ nodeId }) => {
       buttonType={typedState.buttonType ?? 'secondary'}
       onClick={handleLogin}
     >
-      {typedState.label ?? 'GitHub 로그인'}
+      {typedState.label ?? 'Sign in with GitHub'}
     </Button>
   )
 }
@@ -159,7 +159,7 @@ const LogoutButton: React.FC<{ nodeId: string }> = ({ nodeId }) => {
       buttonType={typedState.buttonType ?? 'secondary'}
       onClick={handleLogout}
     >
-      {typedState.text ?? '로그아웃'}
+      {typedState.text ?? 'Log out'}
     </Button>
   )
 }
@@ -179,8 +179,8 @@ const SessionHint: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const typedState = state as SessionHintState
 
   const text = isRefreshing
-    ? (typedState.refreshingText ?? '리프레시 토큰 확인 중...')
-    : (typedState.normalText ?? '세션 만료 3분 전 자동 갱신됩니다.')
+    ? (typedState.refreshingText ?? 'Checking refresh token...')
+    : (typedState.normalText ?? 'Automatically refreshes 3 minutes before session expiration.')
 
   return (
     <span className={typedState.className ?? 'text-xs text-white/60'}>
@@ -270,7 +270,7 @@ const SessionField: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const { lastRefreshAt } = useRefreshSession()
 
   const typedState = state as SessionFieldState
-  const fallback = typedState.fallback ?? '알 수 없음'
+  const fallback = typedState.fallback ?? 'Unknown'
 
   // Data source object for dynamic lookup
   const dataSource: Record<string, unknown> = {
@@ -315,8 +315,8 @@ const RefreshButton: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const typedState = state as RefreshButtonState
 
   const buttonText = isRefreshing
-    ? (typedState.refreshingText ?? '갱신 중')
-    : (typedState.text ?? '세션 갱신')
+    ? (typedState.refreshingText ?? 'Refreshing')
+    : (typedState.text ?? 'Refresh session')
 
   return (
     <button

--- a/apps/nextAuthOauthLoginExample/src/app/lib/sdui-document.ts
+++ b/apps/nextAuthOauthLoginExample/src/app/lib/sdui-document.ts
@@ -63,7 +63,7 @@ export const loginDocument: SduiLayoutDocument = {
                     id: 'description',
                     type: 'Text',
                     state: {
-                      text: 'NextAuth를 이용해 GitHub 로그인을 수행하고, SDUI 템플릿으로 화면을 구성합니다.',
+                      text: 'Use NextAuth to sign in with GitHub and render the UI with the SDUI template.',
                     },
                     attributes: {
                       className: '',
@@ -99,7 +99,7 @@ export const loginDocument: SduiLayoutDocument = {
                             id: 'loading-text',
                             type: 'Span',
                             state: {
-                              text: '세션 확인 중...',
+                              text: 'Checking session...',
                             },
                           },
                         ],
@@ -126,7 +126,7 @@ export const loginDocument: SduiLayoutDocument = {
                             id: 'logout-btn',
                             type: 'LogoutButton',
                             state: {
-                              text: '로그아웃',
+                              text: 'Log out',
                               callbackUrl: '/',
                               buttonStyle: 'filled',
                               size: 'M',
@@ -137,8 +137,8 @@ export const loginDocument: SduiLayoutDocument = {
                             id: 'session-hint',
                             type: 'SessionHint',
                             state: {
-                              refreshingText: '리프레시 토큰 확인 중...',
-                              normalText: '세션 만료 3분 전 자동 갱신됩니다.',
+                              refreshingText: 'Checking refresh token...',
+                              normalText: 'Automatically refreshes 3 minutes before session expiration.',
                               className: 'text-xs text-white/60',
                             },
                           },
@@ -159,7 +159,7 @@ export const loginDocument: SduiLayoutDocument = {
                         id: 'login-btn',
                         type: 'LoginButton',
                         state: {
-                          label: 'GitHub로 로그인',
+                          label: 'Sign in with GitHub',
                           provider: 'github',
                           callbackUrl: '/',
                           buttonStyle: 'outline',
@@ -192,7 +192,7 @@ export const loginDocument: SduiLayoutDocument = {
                         id: 'status-title',
                         type: 'Text',
                         state: {
-                          text: '로그인 상태',
+                          text: 'Login status',
                         },
                         attributes: {
                           as: 'h2',
@@ -203,8 +203,8 @@ export const loginDocument: SduiLayoutDocument = {
                         id: 'refresh-btn',
                         type: 'RefreshButton',
                         state: {
-                          text: '세션 갱신',
-                          refreshingText: '갱신 중',
+                          text: 'Refresh session',
+                          refreshingText: 'Refreshing',
                         },
                       },
                     ],
@@ -223,7 +223,7 @@ export const loginDocument: SduiLayoutDocument = {
                         type: 'SessionField',
                         state: {
                           dataKey: 'status',
-                          label: '세션 상태',
+                          label: 'Session status',
                         },
                       },
                       {
@@ -231,8 +231,8 @@ export const loginDocument: SduiLayoutDocument = {
                         type: 'SessionField',
                         state: {
                           dataKey: 'session.user.name',
-                          label: '사용자',
-                          fallback: '알 수 없음',
+                          label: 'User',
+                          fallback: 'Unknown',
                         },
                       },
                       {
@@ -240,8 +240,8 @@ export const loginDocument: SduiLayoutDocument = {
                         type: 'SessionField',
                         state: {
                           dataKey: 'session.user.email',
-                          label: '이메일',
-                          fallback: '알 수 없음',
+                          label: 'Email',
+                          fallback: 'Unknown',
                         },
                       },
                       {
@@ -249,8 +249,8 @@ export const loginDocument: SduiLayoutDocument = {
                         type: 'SessionField',
                         state: {
                           dataKey: 'session.expires',
-                          label: '세션 만료',
-                          fallback: '알 수 없음',
+                          label: 'Session expires',
+                          fallback: 'Unknown',
                         },
                       },
                       {
@@ -258,8 +258,8 @@ export const loginDocument: SduiLayoutDocument = {
                         type: 'SessionField',
                         state: {
                           dataKey: 'lastRefreshAt',
-                          label: '최근 리프레시',
-                          fallback: '아직 없음',
+                          label: 'Last refresh',
+                          fallback: 'Not yet',
                           formatter: 'date',
                         },
                       },
@@ -289,7 +289,7 @@ export const loginDocument: SduiLayoutDocument = {
                     id: 'token-hint',
                     type: 'Text',
                     state: {
-                      text: 'JWT는 httpOnly 쿠키에 저장되며, 리프레시 토큰은 Supabase DB에 저장됩니다.',
+                      text: 'JWTs are stored in httpOnly cookies, and refresh tokens are stored in the Supabase database.',
                     },
                     attributes: {
                       className: 'text-sm text-gray-600',


### PR DESCRIPTION
### Motivation
- Replace hard-coded reducer action-type strings with a single source of truth to reduce typos and make dispatch usage consistent across the refresh session flow. 
- Convert all Korean UI copy, comments, and error messages to English for consistency in the example app and docs. 
- Keep example README and API comments aligned with the translated UI so external contributors can follow the flow more easily.

### Description
- Define `REFRESH_ACTIONS` and update the `RefreshAction` type, `refreshReducer` `switch` cases, and all `dispatch` calls to use `REFRESH_ACTIONS` in `apps/nextAuthOauthLoginExample/src/app/contexts/refresh-session.context.tsx`.
- Replace Korean strings with English equivalents in the SDUI layout document at `apps/nextAuthOauthLoginExample/src/app/lib/sdui-document.ts` and in UI components at `apps/nextAuthOauthLoginExample/src/app/components/sdui-components.tsx` (labels, button text, hints, fallbacks, and error messages).
- Translate comments in the logout API handler at `apps/nextAuthOauthLoginExample/src/app/api/auth/logout/route.ts` and the app README at `apps/nextAuthOauthLoginExample/README.md` into English.
- Update runtime error messages (for example: `'리프레시 토큰 갱신 실패'` → `'Failed to refresh the token'` and fallback `'알 수 없는 오류'` → `'Unknown error'`).

### Testing
- Ran linting via `turbo run lint` (eslint ran and auto-fixed files) and the lint task completed; remaining output were warnings but the hook allowed the commit to proceed. 
- Ran the test suite via `turbo run test --concurrency=5` which executed Jest across packages and completed with the package test suites passing (including `@lodado/sdui-template` and `@lodado/sdui-template-component`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979fff79ac0832eb223692306b7e1b8)