### PR TITLE
Update zod to latest v4.3.6 across workspace

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,7 +16,7 @@
     "@lodado/sdui-template-component": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "zod": "^4.3.5"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^10.1.10",

--- a/apps/nextAuthOauthLoginExample/package.json
+++ b/apps/nextAuthOauthLoginExample/package.json
@@ -17,7 +17,7 @@
     "next-auth": "5.0.0-beta.30",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "zod": "^4.3.5"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",

--- a/apps/reactGridLayoutExample/package.json
+++ b/apps/reactGridLayoutExample/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^19.2.4",
     "react-grid-layout": "^1.5.2",
     "react-resizable": "^3.0.5",
-    "zod": "^4.3.5"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",

--- a/packages/sdui-template-component/README.md
+++ b/packages/sdui-template-component/README.md
@@ -12,6 +12,16 @@ pnpm add @lodado/sdui-template-component
 yarn add @lodado/sdui-template-component
 ```
 
+This package relies on the latest **zod v4** types for schema validation. Install a compatible zod version:
+
+```bash
+pnpm add zod@^4.3.6
+# or
+npm install zod@^4.3.6
+# or
+yarn add zod@^4.3.6
+```
+
 ## Usage
 
 ```tsx

--- a/packages/sdui-template-component/package.json
+++ b/packages/sdui-template-component/package.json
@@ -62,7 +62,8 @@
     "@lodado/sdui-template": "workspace:*",
     "next": "^14.0.0",
     "react": "^18.0",
-    "react-dom": "^18.0"
+    "react-dom": "^18.0",
+    "zod": "^4.3.6"
   },
   "peerDependenciesMeta": {
     "@types/react": {
@@ -78,8 +79,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "react-hook-form": "^7.70.0",
-    "tailwind-merge": "^2.2.1",
-    "zod": "^3.22.4"
+    "tailwind-merge": "^2.2.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.5",
@@ -97,6 +97,7 @@
     "ts-jest": "29.0.5",
     "tsconfig": "workspace:*",
     "typescript": "^5.4.5",
+    "zod": "^4.3.6",
     "vitest": "^1.6.0"
   },
   "repository": {

--- a/packages/sdui-template/README.md
+++ b/packages/sdui-template/README.md
@@ -44,6 +44,16 @@ pnpm add @lodado/sdui-template
 yarn add @lodado/sdui-template
 ```
 
+This package uses the latest **zod v4** types. Make sure you install a compatible zod version alongside it:
+
+```bash
+pnpm add zod@^4.3.6
+# or
+npm install zod@^4.3.6
+# or
+yarn add zod@^4.3.6
+```
+
 ## Quick Start
 
 ### Basic Usage

--- a/packages/sdui-template/package.json
+++ b/packages/sdui-template/package.json
@@ -39,8 +39,7 @@
   "packageManager": "pnpm@9.0.6",
   "dependencies": {
     "lodash-es": "^4.17.21",
-    "normalizr": "^3.6.2",
-    "zod": "^3.23.8"
+    "normalizr": "^3.6.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.5",
@@ -56,6 +55,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "rollup-config": "workspace:*",
+    "zod": "^4.3.6",
     "ts-jest": "29.0.5",
     "tsconfig": "workspace:*"
   },
@@ -71,7 +71,8 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "react": "^18.0",
-    "react-dom": "^18.0"
+    "react-dom": "^18.0",
+    "zod": "^4.3.6"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/ssr-testing/package.json
+++ b/packages/ssr-testing/package.json
@@ -17,7 +17,7 @@
     "next": "16.1.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "zod": "^3.23.8"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.48.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       zod:
-        specifier: ^4.3.5
-        version: 4.3.5
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@storybook/addon-a11y':
         specifier: ^10.1.10
@@ -136,8 +136,8 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
       zod:
-        specifier: ^4.3.5
-        version: 4.3.5
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.1.18
@@ -197,7 +197,7 @@ importers:
         specifier: ^3.0.5
         version: 3.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zod:
-        specifier: ^4.3.5
+        specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
       '@tailwindcss/postcss':
@@ -444,9 +444,6 @@ importers:
       normalizr:
         specifier: ^3.6.2
         version: 3.6.2
-      zod:
-        specifier: ^3.23.8
-        version: 3.25.76
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.1.5
@@ -493,6 +490,9 @@ importers:
       tsconfig:
         specifier: workspace:*
         version: link:../../configs/tsconfig
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
   packages/sdui-template-component:
     dependencies:
@@ -523,9 +523,6 @@ importers:
       tailwind-merge:
         specifier: ^2.2.1
         version: 2.6.0
-      zod:
-        specifier: ^3.22.4
-        version: 3.25.76
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.1.5
@@ -575,6 +572,9 @@ importers:
       vitest:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.27)(@vitest/browser@4.0.16)(jsdom@27.4.0)(lightningcss@1.30.2)(sass@1.97.2)(terser@5.44.1)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
   packages/ssr-testing:
     dependencies:
@@ -591,8 +591,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@playwright/test':
         specifier: ^1.48.0
@@ -7787,12 +7787,6 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
-  zod@4.3.5:
-    resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
-
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -12165,8 +12159,8 @@ snapshots:
       '@babel/parser': 7.28.5
       eslint: 7.32.0
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.3.6
+      zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -12176,8 +12170,8 @@ snapshots:
       '@babel/parser': 7.28.5
       eslint: 9.39.2(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.3.6
+      zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -16053,12 +16047,8 @@ snapshots:
 
   yoctocolors-cjs@2.1.3: {}
 
-  zod-validation-error@4.0.2(zod@3.25.76):
+  zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
-      zod: 3.25.76
-
-  zod@3.25.76: {}
-
-  zod@4.3.5: {}
+      zod: 4.3.6
 
   zod@4.3.6: {}


### PR DESCRIPTION
### Motivation
- Align template and component libraries, example apps, and SSR test project on the latest `zod` v4 to avoid type/compatibility mismatches between packages. 
- Ensure consumers are instructed to install a matching `zod` version and local dev/test runs use the same version.

### Description
- Bumped `zod` to `^4.3.6` in package `peerDependencies` and `devDependencies` for `packages/sdui-template` and `packages/sdui-template-component`. 
- Updated example apps and `packages/ssr-testing` to depend on `zod@^4.3.6` so workspace examples use the same zod version. 
- Updated `README.md` files for `packages/sdui-template` and `packages/sdui-template-component` to recommend installing `zod@^4.3.6`. 
- Refreshed the lockfile (`pnpm-lock.yaml`) and ran `pnpm install` to capture the updated resolution for `zod@4.3.6`.

### Testing
- Verified current `zod` upstream version with `npm view zod version` (returned `4.3.6`).
- Ran `pnpm install` successfully to update the lockfile and dependency resolutions. 
- Ran the workspace test suite with `pnpm test` (which runs `turbo run test --concurrency=5`), and all package test suites completed successfully while emitting existing `ts-jest` version warnings and some expected console error traces from component tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d67c43720832e8cba6426b6b91647)