### PR TITLE
fix: stabilize rollup cache and improve zod schema typing

### DIFF
--- a/configs/rollup-config/rollup.config.mjs
+++ b/configs/rollup-config/rollup.config.mjs
@@ -5,7 +5,7 @@ import commonjs from "@rollup/plugin-commonjs";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
 import url from "@rollup/plugin-url";
-import { readFileSync } from "fs";
+import { mkdirSync, readFileSync } from "fs";
 import path, { join } from "path";
 import postcssImport from "postcss-import";
 import { nodeExternals } from "rollup-plugin-node-externals";
@@ -42,6 +42,9 @@ if (!packageJSON.publishConfig) {
 const BUILD_OUTPUT_LOCATION = `${dirname}/dist`;
 
 const ENTRY_POINT = `${dirname}/${packageJSON.source}`;
+const CACHE_ROOT = join(dirname, ".cache", "rollup-plugin-typescript2");
+
+mkdirSync(CACHE_ROOT, { recursive: true });
 
 const inputSrc = [
   { input: ENTRY_POINT, format: "es", additionalFolderDirectiory: "client" },
@@ -109,6 +112,7 @@ const rollupConfigFunc = (config) =>
           tsconfig: "./tsconfig.json",
           tsconfigOverride: {},
           useTsconfigDeclarationDir: true,
+          cacheRoot: CACHE_ROOT,
         }),
         peerDepsExternal(),
 

--- a/packages/sdui-design-files/src/generated/theme.css.ts
+++ b/packages/sdui-design-files/src/generated/theme.css.ts
@@ -331,17 +331,29 @@ const spaceContract = {
  *   color: colorVars.text.inverse,
  * })
  */
-export const colorVars = createGlobalThemeContract(colorContract, (value) => `color-${value}`)
+export const colorVars = createGlobalThemeContract(colorContract, (value: string | null, path: string[]) => {
+  const tokenName = value ?? path.join('-')
+  return `color-${tokenName}`
+})
 
 /**
  * Elevation theme contract for vanilla-extract
  */
-export const elevationVars = createGlobalThemeContract(elevationContract, (value) => `elevation-${value}`)
+export const elevationVars = createGlobalThemeContract(
+  elevationContract,
+  (value: string | null, path: string[]) => {
+    const tokenName = value ?? path.join('-')
+    return `elevation-${tokenName}`
+  },
+)
 
 /**
  * Space theme contract for vanilla-extract
  */
-export const spaceVars = createGlobalThemeContract(spaceContract, (value) => `space-${value}`)
+export const spaceVars = createGlobalThemeContract(spaceContract, (value: string | null, path: string[]) => {
+  const tokenName = value ?? path.join('-')
+  return `space-${tokenName}`
+})
 
 // ============================================================================
 // Combined Vars Export

--- a/packages/sdui-template-component/src/features/form/Form.tsx
+++ b/packages/sdui-template-component/src/features/form/Form.tsx
@@ -43,7 +43,7 @@ const FormRoot = <TFieldValues extends FieldValues = FieldValues, TContext = unk
   ...formOptions
 }: FormRootProps<TFieldValues, TContext>) => {
   // Create zodResolver - it automatically extracts error messages from zod schema
-  const resolver = schema ? zodResolver(schema) : undefined
+  const resolver = schema ? zodResolver<TFieldValues, TContext, TFieldValues>(schema) : undefined
 
   const methods = useForm<TFieldValues, TContext>({
     mode: 'onSubmit', // 첫 제출 시에만 validation 실행
@@ -61,7 +61,7 @@ const FormRoot = <TFieldValues extends FieldValues = FieldValues, TContext = unk
 
   const contextValue = React.useMemo<{
     formMethods: UseFormReturn<TFieldValues, TContext>
-    schema?: z.ZodType<any, any, any>
+    schema?: z.ZodType<TFieldValues, TFieldValues>
   }>(
     () => ({
       formMethods: methods,
@@ -119,9 +119,11 @@ export const FormContainer = ({ id, parentPath = [] }: FormContainerProps) => {
   const { renderChildren } = useRenderNode({ nodeId: id, parentPath })
 
   // Get schema from attributes
-  const schemaFromAttributes = attributes?.schema as z.ZodType<any, any, any> | undefined
+  const schemaFromAttributes = attributes?.schema as z.ZodType<FieldValues, FieldValues> | undefined
   const schemaName = attributes?.schemaName as string | undefined
-  const schemaFromRegistry = schemaName ? getSchema(schemaName) : undefined
+  const schemaFromRegistry = schemaName
+    ? (getSchema(schemaName) as z.ZodType<FieldValues, FieldValues> | undefined)
+    : undefined
   const schema = schemaFromAttributes || schemaFromRegistry
 
   // Get onSubmit handler from attributes (can be a function name or handler)

--- a/packages/sdui-template-component/src/features/form/types.ts
+++ b/packages/sdui-template-component/src/features/form/types.ts
@@ -124,7 +124,7 @@ export function registerSchemas<TSchemas extends Record<string, z.ZodTypeAny>>(s
 export interface FormRootProps<TFieldValues extends FieldValues = FieldValues, TContext = unknown>
   extends Omit<UseFormProps<TFieldValues, TContext>, 'resolver'> {
   /** Zod schema for validation */
-  schema?: z.ZodTypeAny
+  schema?: z.ZodType<TFieldValues, TFieldValues>
   /** Form submission handler */
   onSubmit: (data: TFieldValues) => void | Promise<void>
   /** Form children (can access form methods via FormProvider) */


### PR DESCRIPTION
### Motivation
- Prevent intermittent Rollup build failures caused by missing rollup-plugin-typescript2 cache files and eliminate implicit-any TypeScript issues in generated vanilla-extract theme code.
- Make form schema typing explicit and compatible with the `zod` resolver to avoid overload/type errors when using `react-hook-form` + `zod`.

### Description
- Create a stable cache directory and wire it into the Rollup TypeScript plugin by adding `CACHE_ROOT` and passing `cacheRoot` to `rollup-plugin-typescript2`, and ensure the directory exists with `mkdirSync` (`configs/rollup-config/rollup.config.mjs`).
- Tighten generated vanilla-extract callbacks to accept `value: string | null` and `path: string[]`, fallback to `path.join('-')` when `value` is null, and return stable token names for `colorVars`, `elevationVars`, and `spaceVars` (`packages/sdui-design-files/src/generated/theme.css.ts`).
- Align form typings by specifying `z.ZodType<TFieldValues, TFieldValues>` for `FormRootProps.schema` and attribute/registry reads, and call `zodResolver` with explicit generics `zodResolver<TFieldValues, TContext, TFieldValues>` to satisfy overloads (`packages/sdui-template-component/src/features/form/types.ts` and `packages/sdui-template-component/src/features/form/Form.tsx`).

### Testing
- Ran `pnpm build` and verified the monorepo packages build without the previous Rollup/TypeScript cache errors (build completed successfully).
- Ran `pnpm test` and all automated test suites passed: `@lodado/sdui-template` (15 test suites, 69 tests passed) and `@lodado/sdui-template-component` (5 test suites, 79 tests passed), while `@lodado/sdui-design-files` had no tests to run.
- Ran `pnpm lint` as part of pre-commit hooks and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d9ede393c832eba28f244c31abcdb)