### PR TITLE
chore: translate Korean comments to English

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'subject-case': [0], // 대문자/소문자 제한 제거
-    'body-max-line-length': [0], // body 줄 길이 제한 제거
+    'subject-case': [0], // Remove uppercase/lowercase restrictions
+    'body-max-line-length': [0], // Remove body line length limit
   },
 }

--- a/configs/eslint-config/index.js
+++ b/configs/eslint-config/index.js
@@ -27,11 +27,11 @@ module.exports = {
     'class-methods-use-this': 0,
     'react/require-default-props': 0,
     'react/button-has-type': 'off',
-    'react/prop-types': 'off', // TypeScript를 사용하므로 prop-types 불필요
+    'react/prop-types': 'off', // prop-types is unnecessary when using TypeScript
     'react/jsx-no-useless-fragment': 0,
     'react/jsx-props-no-spreading': ['warn'],
-    'jsx-a11y/control-has-associated-label': 'off', // Button은 children으로 라벨 제공
-    'jsx-a11y/button-has-type': 'off', // TypeScript로 타입 안전성 보장, 동적 type prop 허용
+    'jsx-a11y/control-has-associated-label': 'off', // Buttons provide labels via children
+    'jsx-a11y/button-has-type': 'off', // TypeScript ensures type safety; allow dynamic type props
 
     'import/no-extraneous-dependencies': [
       1,

--- a/configs/rollup-config/rollup.config.mjs
+++ b/configs/rollup-config/rollup.config.mjs
@@ -104,7 +104,7 @@ const rollupConfigFunc = (config) =>
         }),
 
         /**
-         * modulesOnly 옵션이 있어야 turbo repo에서 타입에러나지 않고 번들링됨
+         * The modulesOnly option is required to bundle in the turbo repo without type errors.
          */
         nodeResolve({ extensions, modulesOnly: true }),
 
@@ -157,9 +157,9 @@ const rollupConfigFunc = (config) =>
           },
 
           extract: true,
-          inject: true, // CSS를 JS 파일에 인라인으로 포함
-          minimize: true, // CSS 최소화
-          sourceMap: true, // 소스맵 생성
+          inject: true, // Inline CSS into the JS file
+          minimize: true, // Minify CSS
+          sourceMap: true, // Generate source maps
         }),
 
         visualizer({ filename: "stats.html" }),

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ const jestConfig = require('./configs/jest-config/jest.config')
 
 const customJestConfig = {
   ...jestConfig,
-  // 패키지별 설정을 여기에 추가
+  // Add per-package config here
 }
 
 module.exports = customJestConfig

--- a/packages/sdui-design-files/jest.config.js
+++ b/packages/sdui-design-files/jest.config.js
@@ -2,7 +2,7 @@ const jestConfig = require('jest-config/jest.config.js')
 
 const customJestConfig = {
   ...jestConfig,
-  // 패키지별 설정을 여기에 추가
+  // Add per-package config here
 }
 
 module.exports = customJestConfig

--- a/packages/sdui-design-files/src/layout.css
+++ b/packages/sdui-design-files/src/layout.css
@@ -1,27 +1,27 @@
 /**
  * Layout Variables
  * 
- * Safe Area Insets: iOS Safari 등에서 노치, 홈 인디케이터가 있는 부분을 피하기 위한 CSS 환경 변수
- * - env(): 최신 브라우저에서 지원
- * - constant(): 구형 iOS Safari에서 지원 (하위 호환성)
+ * Safe Area Insets: CSS environment variables to avoid the notch or home indicator area on iOS Safari, etc.
+ * - env(): supported in modern browsers
+ * - constant(): supported in older iOS Safari (backward compatibility)
  * 
- * Header/Footer Height: 일관된 레이아웃을 위한 높이 변수
+ * Header/Footer Height: height variables for consistent layout
  */
 
 :root {
-  /* Safe Area Insets - Top (상단) */
+  /* Safe Area Insets - Top (upper) */
   --safe-area-top: constant(safe-area-inset-top, 0);
   --safe-area-top: env(safe-area-inset-top, 0);
 
-  /* Safe Area Insets - Right (우측) */
+  /* Safe Area Insets - Right */
   --safe-area-right: constant(safe-area-inset-right, 0);
   --safe-area-right: env(safe-area-inset-right, 0);
 
-  /* Safe Area Insets - Bottom (하단) */
+  /* Safe Area Insets - Bottom */
   --safe-area-bottom: constant(safe-area-inset-bottom, 0);
   --safe-area-bottom: env(safe-area-inset-bottom, 0);
 
-  /* Safe Area Insets - Left (좌측) */
+  /* Safe Area Insets - Left */
   --safe-area-left: constant(safe-area-inset-left, 0);
   --safe-area-left: env(safe-area-inset-left, 0);
 
@@ -33,8 +33,8 @@
 /**
  * Body Safe Area Padding
  * 
- * Safe area insets를 body에 padding으로 적용하여
- * 콘텐츠가 노치나 홈 인디케이터 영역을 침범하지 않도록 합니다.
+ * Apply safe area insets as body padding
+ * so content does not overlap the notch or home indicator area.
  */
 body {
   margin: 0;

--- a/packages/sdui-template-component/jest.config.js
+++ b/packages/sdui-template-component/jest.config.js
@@ -2,7 +2,7 @@ const jestConfig = require('jest-config/jest.config.js')
 
 const customJestConfig = {
   ...jestConfig,
-  // 패키지별 설정을 여기에 추가
+  // Add per-package config here
   testPathIgnorePatterns: [
     ...(jestConfig.testPathIgnorePatterns || []),
     '<rootDir>/src/__tests__/utils/',

--- a/packages/sdui-template-component/src/features/form/Form.tsx
+++ b/packages/sdui-template-component/src/features/form/Form.tsx
@@ -46,8 +46,8 @@ const FormRoot = <TFieldValues extends FieldValues = FieldValues, TContext = unk
   const resolver = schema ? zodResolver<TFieldValues, TContext, TFieldValues>(schema) : undefined
 
   const methods = useForm<TFieldValues, TContext>({
-    mode: 'onSubmit', // 첫 제출 시에만 validation 실행
-    reValidateMode: 'onChange', // 제출 후에는 onChange 시 실시간 revalidate
+    mode: 'onSubmit', // Run validation only on the first submit
+    reValidateMode: 'onChange', // Revalidate on change after submission
     ...formOptions,
     resolver: resolver as never,
   })

--- a/packages/sdui-template-component/src/features/form/__tests__/form.logic.test.tsx
+++ b/packages/sdui-template-component/src/features/form/__tests__/form.logic.test.tsx
@@ -147,8 +147,8 @@ describe('Form - Logic Tests', () => {
         )
 
         const label = screen.getByText('이메일')
-        // getByLabelText는 label의 textContent를 기준으로 찾으므로, required indicator(*)가 포함된 경우 정확히 매칭해야 함
-        // 또는 role을 사용하여 찾을 수 있음
+        // getByLabelText matches by label textContent, so include the required indicator (*) for exact matching
+        // Alternatively, you can query by role
         const input = screen.getByRole('textbox', { name: /이메일/ })
 
         expect(label).toHaveTextContent('이메일*')

--- a/packages/sdui-template-component/src/features/title/components/Title.tsx
+++ b/packages/sdui-template-component/src/features/title/components/Title.tsx
@@ -55,7 +55,7 @@ export const Title = ({ id, parentPath = [] }: TitleProps) => {
           </div>
         )}
 
-        {/* Middle section - absolute로 중앙 정렬 */}
+        {/* Middle section - centered with absolute positioning */}
         {middleChildren.length > 0 && (
           <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center">
             {middleChildren.map((childId) => (

--- a/packages/sdui-template-component/src/features/title/types.ts
+++ b/packages/sdui-template-component/src/features/title/types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-// Logo 컴포넌트 상태 스키마
+// Logo component state schema
 export const logoStateSchema = z.object({
   src: z.string(),
   alt: z.string(),

--- a/packages/sdui-template-component/src/shared/ui/button/types.ts
+++ b/packages/sdui-template-component/src/shared/ui/button/types.ts
@@ -81,7 +81,7 @@ export type ButtonSpacing = 'default' | 'compact'
  *
  * @example
  * ```tsx
- * // asChild를 사용하여 Link에 Button 스타일 적용
+ * // Use asChild to apply Button styles to a Link
  * <Button asChild appearance="subtle">
  *   <Link href="/about">About</Link>
  * </Button>

--- a/packages/sdui-template-component/src/shared/ui/card/Card.tsx
+++ b/packages/sdui-template-component/src/shared/ui/card/Card.tsx
@@ -14,7 +14,7 @@ import type { CardProps } from './types'
  *
  * @example
  * ```tsx
- * <Card title="학습 가이드">
+ * <Card title="Learning Guide">
  *   <div>Card content</div>
  * </Card>
  * ```

--- a/packages/sdui-template-component/src/shared/ui/card/types.ts
+++ b/packages/sdui-template-component/src/shared/ui/card/types.ts
@@ -17,7 +17,7 @@ import { z } from 'zod'
  *
  * @example
  * ```tsx
- * <Card title="학습 가이드">
+ * <Card title="Learning Guide">
  *   <div>Card content</div>
  * </Card>
  * ```

--- a/packages/sdui-template-component/src/shared/ui/div/ErrorBoundary.tsx
+++ b/packages/sdui-template-component/src/shared/ui/div/ErrorBoundary.tsx
@@ -9,9 +9,9 @@ interface ErrorBoundaryProps {
   children: ReactNode
   fallback?: ReactNode | ((error: Error, errorInfo: React.ErrorInfo) => ReactNode)
   onError?: (error: Error, errorInfo: React.ErrorInfo) => void
-  /** SDUI 노드 ID (에러 컨텍스트에 포함) */
+  /** SDUI node ID (included in error context) */
   nodeId?: string
-  /** 부모 경로 (에러 컨텍스트에 포함) */
+  /** Parent path (included in error context) */
   parentPath?: string[]
 }
 
@@ -22,7 +22,7 @@ interface ErrorBoundaryState {
 }
 
 /**
- * ErrorBoundary 내부 구현 (Context 없이)
+ * Internal ErrorBoundary implementation (without context).
  */
 class ErrorBoundaryInner extends Component<
   ErrorBoundaryProps & { reportSituation?: (situation: ErrorSituation) => void },

--- a/packages/sdui-template-component/src/shared/ui/div/error-policy/AlertErrorPolicy.ts
+++ b/packages/sdui-template-component/src/shared/ui/div/error-policy/AlertErrorPolicy.ts
@@ -2,14 +2,14 @@ import type { ErrorPolicy, ErrorSituation } from './types'
 
 /**
  * Alert Error Policy
- * 에러 발생 시 브라우저 alert로 사용자에게 알림을 표시하는 Policy
+ * Policy that notifies users via a browser alert when an error occurs.
  */
 export class AlertErrorPolicy implements ErrorPolicy {
   constructor(
     private options: {
-      /** catch 단계에서만 alert 표시할지 여부 */
+      /** Whether to show alerts only during the catch phase */
       onlyOnCatch?: boolean
-      /** alert 메시지 포맷 함수 */
+      /** Alert message formatting function */
       formatMessage?: (situation: ErrorSituation) => string
     } = {}
   ) {
@@ -25,7 +25,7 @@ export class AlertErrorPolicy implements ErrorPolicy {
   }
 
   handleSituation(situation: ErrorSituation): void {
-    // onlyOnCatch가 true이고 catch 단계가 아니면 무시
+    // Ignore when onlyOnCatch is true and this is not the catch phase
     if (this.options.onlyOnCatch && situation.lifecycle.phase !== 'catch') {
       return
     }

--- a/packages/sdui-template-component/src/shared/ui/div/error-policy/CompositeErrorPolicy.ts
+++ b/packages/sdui-template-component/src/shared/ui/div/error-policy/CompositeErrorPolicy.ts
@@ -4,15 +4,15 @@ import type { ErrorPolicy, ErrorSituation } from './types'
  * Composite Error Policy Options
  */
 export interface CompositeErrorPolicyOptions {
-  /** 실행 방식: 순차 또는 병렬 */
+  /** Execution mode: sequential or parallel */
   execution?: 'sequential' | 'parallel'
-  /** 에러 발생 시 중단 여부 */
+  /** Whether to stop on error */
   stopOnError?: boolean
 }
 
 /**
  * Composite Error Policy
- * 여러 Policy를 조합하여 실행하는 Policy
+ * Policy that executes multiple policies together.
  */
 export class CompositeErrorPolicy implements ErrorPolicy {
   constructor(
@@ -55,7 +55,7 @@ export class CompositeErrorPolicy implements ErrorPolicy {
       if (this.options.stopOnError) {
         throw err
       }
-      // 한 Policy가 실패해도 다른 Policy는 계속 실행
+      // Continue executing other policies even if one fails
       // eslint-disable-next-line no-console
       console.error('Error in policy handler:', err)
     }

--- a/packages/sdui-template-component/src/shared/ui/div/error-policy/ErrorPolicyBuilder.ts
+++ b/packages/sdui-template-component/src/shared/ui/div/error-policy/ErrorPolicyBuilder.ts
@@ -4,16 +4,16 @@ import type { ErrorPolicy } from './types'
 
 /**
  * Error Policy Builder
- * 여러 Policy를 체이닝 방식으로 등록할 수 있는 Builder
+ * Builder that registers multiple policies in a chained manner.
  */
 export class ErrorPolicyBuilder {
   private policies: ErrorPolicy[] = []
   private options: CompositeErrorPolicyOptions = {}
 
   /**
-   * Policy를 추가합니다.
-   * @param policy - 추가할 Policy (null/undefined는 무시)
-   * @returns this (체이닝)
+   * Add a policy.
+   * @param policy - Policy to add (ignores null/undefined)
+   * @returns this (for chaining)
    */
   add(policy: ErrorPolicy | null | undefined): this {
     if (policy) {
@@ -23,10 +23,10 @@ export class ErrorPolicyBuilder {
   }
 
   /**
-   * 조건부로 Policy를 추가합니다.
-   * @param condition - 추가 조건
-   * @param policy - 추가할 Policy 또는 Policy 생성 함수
-   * @returns this (체이닝)
+   * Conditionally add a policy.
+   * @param condition - Condition to add
+   * @param policy - Policy to add or policy factory
+   * @returns this (for chaining)
    */
   addIf(
     condition: boolean,
@@ -41,9 +41,9 @@ export class ErrorPolicyBuilder {
   }
 
   /**
-   * 여러 Policy를 한 번에 추가합니다.
-   * @param policies - 추가할 Policy 배열
-   * @returns this (체이닝)
+   * Add multiple policies at once.
+   * @param policies - Array of policies to add
+   * @returns this (for chaining)
    */
   addMany(...policies: (ErrorPolicy | null | undefined)[]): this {
     policies.forEach(policy => this.add(policy))
@@ -51,9 +51,9 @@ export class ErrorPolicyBuilder {
   }
 
   /**
-   * Composite Policy 옵션을 설정합니다.
-   * @param options - 옵션
-   * @returns this (체이닝)
+   * Set composite policy options.
+   * @param options - Options
+   * @returns this (for chaining)
    */
   withOptions(options: CompositeErrorPolicyOptions): this {
     this.options = { ...this.options, ...options }
@@ -61,8 +61,8 @@ export class ErrorPolicyBuilder {
   }
 
   /**
-   * 등록된 Policy들을 조합하여 최종 Policy를 생성합니다.
-   * @returns 최종 Policy 또는 null (Policy가 없는 경우)
+   * Combine registered policies into the final policy.
+   * @returns Final policy or null (when no policies exist)
    */
   build(): ErrorPolicy | null {
     if (this.policies.length === 0) {
@@ -76,18 +76,18 @@ export class ErrorPolicyBuilder {
 }
 
 /**
- * Error Policy 생성 헬퍼 함수
+ * Error policy creation helper
  */
 export const createErrorPolicy = {
   /**
-   * 새로운 Builder 인스턴스를 생성합니다.
+   * Create a new builder instance.
    */
   builder: () => new ErrorPolicyBuilder(),
 
   /**
-   * 여러 Policy를 체이닝하여 하나의 Policy로 만듭니다.
-   * @param policies - 조합할 Policy 배열
-   * @returns 최종 Policy 또는 null
+   * Chain multiple policies into a single policy.
+   * @param policies - Array of policies to combine
+   * @returns Final policy or null
    */
   chain: (...policies: ErrorPolicy[]): ErrorPolicy | null => {
     const builder = new ErrorPolicyBuilder()

--- a/packages/sdui-template-component/src/shared/ui/div/error-policy/ErrorReportingContext.tsx
+++ b/packages/sdui-template-component/src/shared/ui/div/error-policy/ErrorReportingContext.tsx
@@ -15,8 +15,8 @@ import type { ErrorPolicy, ErrorSituation } from './types'
  */
 interface ErrorReportingContextValue {
   /**
-   * 에러 상황을 보고합니다.
-   * @param situation - 에러 상황 정보
+   * Report an error situation.
+   * @param situation - Error situation details
    */
   reportSituation: (situation: ErrorSituation) => void
 }
@@ -31,16 +31,16 @@ const ErrorReportingContext =
  * Error Reporting Provider Props
  */
 interface ErrorReportingProviderProps {
-  /** 자식 컴포넌트 */
+  /** Child components */
   children: ReactNode
-  /** 에러 처리 정책 */
+  /** Error handling policy */
   policy: ErrorPolicy | null
 }
 
 /**
  * Error Reporting Provider
  *
- * ErrorBoundary에서 발생한 에러 상황을 Policy로 전달하는 Provider입니다.
+ * Provider that passes ErrorBoundary error situations to a policy.
  *
  * @example
  * ```tsx
@@ -65,7 +65,7 @@ export const ErrorReportingProvider: React.FC<
 
       try {
         const result = policy.handleSituation(situation)
-        // Promise인 경우 처리 (에러는 무시)
+        // Handle Promise results (ignore errors)
         if (result instanceof Promise) {
           result.catch(err => {
             console.error('Error in policy handler:', err)
@@ -95,10 +95,10 @@ export const ErrorReportingProvider: React.FC<
 /**
  * useErrorReportingContext Hook
  *
- * Error Reporting Context를 가져옵니다.
- * Provider 외부에서 사용 시 null을 반환합니다.
+ * Get the Error Reporting Context.
+ * Returns null when used outside the provider.
  *
- * @returns ErrorReportingContextValue 또는 null
+ * @returns ErrorReportingContextValue or null
  */
 export const useErrorReportingContext =
   (): ErrorReportingContextValue | null => {

--- a/packages/sdui-template-component/src/shared/ui/div/error-policy/types.ts
+++ b/packages/sdui-template-component/src/shared/ui/div/error-policy/types.ts
@@ -2,64 +2,64 @@ import type React from 'react'
 
 /**
  * Error Context
- * 에러가 발생한 위치와 관련 메타데이터
+ * Metadata related to where an error occurred.
  */
 export interface ErrorContext {
-  /** SDUI 노드 ID */
+  /** SDUI node ID */
   nodeId?: string
-  /** 컴포넌트 이름 */
+  /** Component name */
   componentName?: string
-  /** 에러 발생 시각 */
+  /** Error timestamp */
   timestamp: number
-  /** ErrorBoundary ID (여러 Boundary가 있을 경우 구분) */
+  /** ErrorBoundary ID (used to distinguish multiple boundaries) */
   errorBoundaryId?: string
-  /** 부모 경로 (SDUI 계층 구조) */
+  /** Parent path (SDUI hierarchy) */
   parentPath?: string[]
-  /** 추가 메타데이터 */
+  /** Additional metadata */
   metadata?: Record<string, unknown>
 }
 
 /**
  * Error Situation
- * ErrorBoundary에서 Policy로 전달하는 상황 정보
+ * Situation details passed from ErrorBoundary to a policy.
  */
 export interface ErrorSituation {
-  /** 에러 객체 */
+  /** Error object */
   error: Error
-  /** React ErrorInfo (componentDidCatch에서 제공) */
+  /** React ErrorInfo (provided by componentDidCatch) */
   errorInfo?: React.ErrorInfo
 
-  /** 컨텍스트 정보 */
+  /** Context info */
   context: ErrorContext
 
-  /** 생명주기 정보 */
+  /** Lifecycle info */
   lifecycle: {
-    /** 현재 생명주기 단계 */
+    /** Current lifecycle phase */
     phase: 'mount' | 'update' | 'unmount' | 'catch' | 'recovery'
-    /** 이전 상태 */
+    /** Previous state */
     previousState?: {
       hasError: boolean
       error: Error | null
     }
-    /** 현재 상태 */
+    /** Current state */
     currentState: {
       hasError: boolean
       error: Error | null
     }
   }
 
-  /** 추가 메타데이터 */
+  /** Additional metadata */
   metadata?: Record<string, unknown>
 }
 
 /**
  * Error Policy
- * 에러 상황을 처리하는 정책 인터페이스
+ * Policy interface for handling error situations.
  */
 export interface ErrorPolicy {
   /**
-   * 에러 상황을 처리합니다.
-   * @param situation - 에러 상황 정보
+   * Handle an error situation.
+   * @param situation - Error situation details
    */
   handleSituation(situation: ErrorSituation): void | Promise<void>
 }

--- a/packages/sdui-template-component/src/shared/ui/icon/types.ts
+++ b/packages/sdui-template-component/src/shared/ui/icon/types.ts
@@ -74,7 +74,7 @@ export type IconSize =
  *
  * @example
  * ```tsx
- * // asChild를 사용하여 Link에 Icon 스타일 적용
+ * // Use asChild to apply Icon styles to a Link
  * <Icon asChild size="24px">
  *   <a href="/about">
  *     <svg>...</svg>

--- a/packages/sdui-template-component/src/shared/ui/list/List.tsx
+++ b/packages/sdui-template-component/src/shared/ui/list/List.tsx
@@ -28,8 +28,8 @@ import type {
  *     <BookIcon />
  *   </List.Icon>
  *   <List.Content>
- *     <List.Title>기사 읽기</List.Title>
- *     <List.Description>오늘의 추천 기사를 읽고 단어를 저장하세요</List.Description>
+ *     <List.Title>Read Article</List.Title>
+ *     <List.Description>Read today’s recommended article and save new words.</List.Description>
  *   </List.Content>
  *   <List.Arrow />
  * </List>
@@ -126,8 +126,8 @@ ListIcon.displayName = 'List.Icon'
  * @example
  * ```tsx
  * <List.Content>
- *   <List.Title>기사 읽기</List.Title>
- *   <List.Description>오늘의 추천 기사를 읽고 단어를 저장하세요</List.Description>
+ *   <List.Title>Read Article</List.Title>
+ *   <List.Description>Read today’s recommended article and save new words.</List.Description>
  * </List.Content>
  * ```
  */
@@ -157,7 +157,7 @@ ListContent.displayName = 'List.Content'
  *
  * @example
  * ```tsx
- * <List.Title>기사 읽기</List.Title>
+ * <List.Title>Read Article</List.Title>
  * ```
  */
 const ListTitle = React.forwardRef<HTMLDivElement, ListTitleProps>(
@@ -186,7 +186,7 @@ ListTitle.displayName = 'List.Title'
  *
  * @example
  * ```tsx
- * <List.Description>오늘의 추천 기사를 읽고 단어를 저장하세요</List.Description>
+ * <List.Description>Read today’s recommended article and save new words.</List.Description>
  * ```
  */
 const ListDescription = React.forwardRef<HTMLDivElement, ListDescriptionProps>(

--- a/packages/sdui-template-component/src/shared/ui/list/types.ts
+++ b/packages/sdui-template-component/src/shared/ui/list/types.ts
@@ -23,8 +23,8 @@ import { z } from 'zod'
  *     <BookIcon />
  *   </List.Icon>
  *   <List.Content>
- *     <List.Title>기사 읽기</List.Title>
- *     <List.Description>오늘의 추천 기사를 읽고 단어를 저장하세요</List.Description>
+ *     <List.Title>Read Article</List.Title>
+ *     <List.Description>Read today’s recommended article and save new words.</List.Description>
  *   </List.Content>
  *   <List.Arrow />
  * </List>

--- a/packages/sdui-template-component/src/shared/ui/tooltip/useTooltipState.ts
+++ b/packages/sdui-template-component/src/shared/ui/tooltip/useTooltipState.ts
@@ -36,7 +36,7 @@ export function useTooltipState({ open, defaultOpen }: UseTooltipStateProps) {
 
   const handleOpenChange = (newOpen: boolean) => {
     if (!isControlled) {
-      // hover를 지원하지 않는 디바이스(모바일)에서는 hover로 닫히지 않도록 함
+      // On devices without hover (mobile), prevent closing via hover
       if (!hasHover && !open && !internalOpen) {
         return
       }

--- a/packages/sdui-template-component/src/shared/utils/request/request.ts
+++ b/packages/sdui-template-component/src/shared/utils/request/request.ts
@@ -6,9 +6,9 @@ class MockController {
 }
 
 /**
- *  data fetch를 위한 request 함수
- *  data (body)는 string으로 넣을것
- *  baseUrl은 각 앱에서 주입해야 함 (서버: headers에서, 브라우저: window.location.origin)
+ * Request function for data fetching.
+ * Provide data (body) as a string.
+ * baseUrl must be injected by each app (server: from headers, browser: window.location.origin).
  */
 export const request = async <T>({
   method = 'GET',
@@ -43,7 +43,7 @@ export const request = async <T>({
     timeoutId?.unref?.()
   } else {
     /**
-     * server component에서 서버에 api 호출시 cookie 정보를 빼먹어서 명시적으로 넣어줌
+     * Server components can omit cookie info when calling server APIs, so we set it explicitly.
      */
     const cookieString = await parseServerCookie()
 
@@ -63,7 +63,7 @@ export const request = async <T>({
     headers: requestHeaders,
     ...(!isServerSide() && isSignalRequired ? { signal: controller.signal } : {}),
 
-    /** ISR 때 이상하게 동작함 */
+    /** Behaves oddly during ISR */
     cache: 'no-cache',
     ...options,
   })

--- a/packages/sdui-template/jest.config.js
+++ b/packages/sdui-template/jest.config.js
@@ -2,7 +2,7 @@ const jestConfig = require('jest-config/jest.config.js')
 
 const customJestConfig = {
   ...jestConfig,
-  // 패키지별 설정을 여기에 추가
+  // Add per-package config here
   testPathIgnorePatterns: [...(jestConfig.testPathIgnorePatterns || []), '<rootDir>/src/__tests__/utils/'],
 }
 

--- a/packages/sdui-template/src/__tests__/scenario/node-not-found.test.tsx
+++ b/packages/sdui-template/src/__tests__/scenario/node-not-found.test.tsx
@@ -39,7 +39,7 @@ const NodeNotFoundTest: React.FC = () => {
       newErrors.getNodeTypeById = e instanceof Error ? e.message : String(e)
     }
 
-    // Test getLayoutStateById (노드가 없으면 NodeNotFoundError)
+    // Test getLayoutStateById (NodeNotFoundError when the node is missing)
     try {
       store.getLayoutStateById('non-existent-node')
     } catch (e) {

--- a/packages/sdui-template/src/__tests__/scenario/node-reference-subscription.test.tsx
+++ b/packages/sdui-template/src/__tests__/scenario/node-reference-subscription.test.tsx
@@ -52,7 +52,7 @@ describe('Node Reference Subscription', () => {
       const targetNode = referencedNodesMap['target-node']
 
       React.useEffect(() => {
-        // 100ms 후에 참조된 노드의 state를 변경
+        // Update the referenced node state after 100ms
         const timer = setTimeout(() => {
           store.updateNodeState('target-node', { count: 42 })
         }, 100)
@@ -80,10 +80,10 @@ describe('Node Reference Subscription', () => {
       />,
     )
 
-    // 초기값 확인
+    // Verify initial value
     expect(screen.getByTestId('target-count-source-node')).toHaveTextContent('0')
 
-    // state 변경 후 리렌더링 확인
+    // Verify re-render after state change
     await waitFor(
       () => {
         expect(screen.getByTestId('target-count-source-node')).toHaveTextContent('42')
@@ -115,7 +115,7 @@ describe('Node Reference Subscription', () => {
       },
     })
 
-    // Toggle 컴포넌트: 클릭하면 자신의 state를 변경
+    // Toggle component: clicking updates its own state
     const ToggleComponent: React.FC<{ nodeId: string }> = ({ nodeId }) => {
       const { state } = useSduiNodeSubscription({
         nodeId,
@@ -137,7 +137,7 @@ describe('Node Reference Subscription', () => {
       )
     }
 
-    // StatusDisplay 컴포넌트: reference를 통해 toggle-node의 상태를 표시
+    // StatusDisplay component: shows toggle-node state via reference
     const StatusDisplayComponent: React.FC<{ nodeId: string }> = ({ nodeId }) => {
       const { referencedNodesMap } = useSduiNodeReference({ nodeId })
 
@@ -171,15 +171,15 @@ describe('Node Reference Subscription', () => {
       />,
     )
 
-    // 초기 상태 확인: toggle은 OFF, status-display도 OFF 표시
+    // Verify initial state: toggle is OFF, status-display shows OFF
     expect(screen.getByTestId('toggle-status-toggle-node')).toHaveTextContent('OFF')
     expect(screen.getByTestId('status-value-status-display')).toHaveTextContent('OFF')
 
-    // Toggle 버튼 클릭
+    // Click the Toggle button
     const toggleButton = screen.getByTestId('toggle-button-toggle-node')
     fireEvent.click(toggleButton)
 
-    // 상태가 ON으로 변경되었는지 확인
+    // Verify state changed to ON
     await waitFor(
       () => {
         expect(screen.getByTestId('toggle-status-toggle-node')).toHaveTextContent('ON')
@@ -188,10 +188,10 @@ describe('Node Reference Subscription', () => {
       { timeout: 500 },
     )
 
-    // 다시 클릭하여 OFF로 변경
+    // Click again to change back to OFF
     fireEvent.click(toggleButton)
 
-    // 상태가 OFF로 변경되었는지 확인
+    // Verify state changed to OFF
     await waitFor(
       () => {
         expect(screen.getByTestId('toggle-status-toggle-node')).toHaveTextContent('OFF')
@@ -216,7 +216,7 @@ describe('Node Reference Subscription', () => {
       },
     })
 
-    // React의 에러 경계를 사용하여 에러를 catch
+    // Catch errors using a React error boundary
     class TestErrorBoundary extends React.Component<{ children: React.ReactNode }, { error: Error | null }> {
       constructor(props: { children: React.ReactNode }) {
         super(props)
@@ -229,7 +229,7 @@ describe('Node Reference Subscription', () => {
       }
 
       componentDidCatch(error: Error) {
-        // 에러 로깅 등
+        // Error logging, etc.
       }
 
       render() {
@@ -244,8 +244,8 @@ describe('Node Reference Subscription', () => {
       }
     }
 
-    // useSduiNodeReference를 호출하는 컴포넌트
-    // 참조된 노드가 없으면 exists: false를 반환합니다 (에러를 throw하지 않음)
+    // Component that calls useSduiNodeReference
+    // Returns exists: false when the referenced node is missing (no error thrown)
     const ReferenceTestComponent: React.FC<{ nodeId: string }> = ({ nodeId }) => {
       const { referencedNodes, hasReference } = useSduiNodeReference({ nodeId })
       const nonExistentNode = referencedNodes.find((n) => n.id === 'non-existent-node')
@@ -272,7 +272,7 @@ describe('Node Reference Subscription', () => {
       />,
     )
 
-    // 참조는 있지만 존재하지 않는 노드는 exists: false를 반환
+    // References exist, but missing nodes return exists: false
     expect(screen.getByTestId('has-reference')).toHaveTextContent('true')
     expect(screen.getByTestId('non-existent-exists')).toHaveTextContent('false')
   })
@@ -314,12 +314,12 @@ describe('Node Reference Subscription', () => {
       const target2 = referencedNodesMap['target-2']
 
       React.useEffect(() => {
-        // 100ms 후에 첫 번째 참조된 노드의 state를 변경
+        // Update the first referenced node state after 100ms
         const timer1 = setTimeout(() => {
           store.updateNodeState('target-1', { count: 42 })
         }, 100)
 
-        // 200ms 후에 두 번째 참조된 노드의 state를 변경
+        // Update the second referenced node state after 200ms
         const timer2 = setTimeout(() => {
           store.updateNodeState('target-2', { count: 99 })
         }, 200)
@@ -352,11 +352,11 @@ describe('Node Reference Subscription', () => {
       />,
     )
 
-    // 초기값 확인
+    // Verify initial values
     expect(screen.getByTestId('target-1-count-source-node')).toHaveTextContent('0')
     expect(screen.getByTestId('target-2-count-source-node')).toHaveTextContent('10')
 
-    // 첫 번째 노드 state 변경 후 리렌더링 확인
+    // Verify re-render after the first node state change
     await waitFor(
       () => {
         expect(screen.getByTestId('target-1-count-source-node')).toHaveTextContent('42')
@@ -364,7 +364,7 @@ describe('Node Reference Subscription', () => {
       { timeout: 500 },
     )
 
-    // 두 번째 노드 state 변경 후 리렌더링 확인
+    // Verify re-render after the second node state change
     await waitFor(
       () => {
         expect(screen.getByTestId('target-2-count-source-node')).toHaveTextContent('99')
@@ -395,7 +395,7 @@ describe('Node Reference Subscription', () => {
       },
     })
 
-    // React의 에러 경계를 사용하여 에러를 catch
+    // Catch errors using a React error boundary
     class TestErrorBoundary extends React.Component<{ children: React.ReactNode }, { error: Error | null }> {
       constructor(props: { children: React.ReactNode }) {
         super(props)
@@ -408,7 +408,7 @@ describe('Node Reference Subscription', () => {
       }
 
       componentDidCatch(error: Error) {
-        // 에러 로깅 등
+        // Error logging, etc.
       }
 
       render() {
@@ -423,8 +423,8 @@ describe('Node Reference Subscription', () => {
       }
     }
 
-    // useSduiNodeReference를 호출하는 컴포넌트
-    // 여러 reference 중 존재하지 않는 노드는 exists: false를 반환합니다 (에러를 throw하지 않음)
+    // Component that calls useSduiNodeReference
+    // Missing nodes among multiple references return exists: false (no error thrown)
     const ReferenceTestComponent: React.FC<{ nodeId: string }> = ({ nodeId }) => {
       const { referencedNodes, hasReference } = useSduiNodeReference({ nodeId })
       const target1 = referencedNodes.find((n) => n.id === 'target-1')
@@ -453,7 +453,7 @@ describe('Node Reference Subscription', () => {
       />,
     )
 
-    // 참조는 있지만 존재하지 않는 노드는 exists: false를 반환
+    // References exist, but missing nodes return exists: false
     expect(screen.getByTestId('has-reference')).toHaveTextContent('true')
     expect(screen.getByTestId('target-1-exists')).toHaveTextContent('true')
     expect(screen.getByTestId('non-existent-exists')).toHaveTextContent('false')

--- a/packages/sdui-template/src/__tests__/scenario/node-reference.test.tsx
+++ b/packages/sdui-template/src/__tests__/scenario/node-reference.test.tsx
@@ -537,11 +537,11 @@ describe('Node Reference', () => {
           const [reference, setReference] = React.useState<string | string[] | undefined>()
 
           React.useEffect(() => {
-            // 초기 reference 가져오기
+            // Get initial reference
             const initialRef = store.getReferenceById('source-node')
             setReference(initialRef)
 
-            // reference 업데이트
+            // Update reference
             store.updateNodeReference('source-node', 'target-2')
             const updatedRef = store.getReferenceById('source-node')
             setReference(updatedRef)
@@ -594,7 +594,7 @@ describe('Node Reference', () => {
           const [reference, setReference] = React.useState<string | string[] | undefined>()
 
           React.useEffect(() => {
-            // 여러 reference로 업데이트
+            // Update to multiple references
             store.updateNodeReference('source-node', ['target-1', 'target-2'])
             const updatedRef = store.getReferenceById('source-node')
             setReference(updatedRef)
@@ -647,7 +647,7 @@ describe('Node Reference', () => {
           const [reference, setReference] = React.useState<string | string[] | undefined>()
 
           React.useEffect(() => {
-            // reference 제거
+            // Remove reference
             store.updateNodeReference('source-node', undefined)
             const updatedRef = store.getReferenceById('source-node')
             setReference(updatedRef)

--- a/packages/sdui-template/src/__tests__/scenario/parent-path.test.tsx
+++ b/packages/sdui-template/src/__tests__/scenario/parent-path.test.tsx
@@ -13,7 +13,7 @@ import { useRenderNode, useSduiNodeSubscription } from '../../react-wrapper/hook
 import { createTestDocument } from '../utils/dev-utils'
 
 /**
- * 각 레벨의 컴포넌트가 parentPath를 받아서 표시하는 테스트 컴포넌트
+ * Test component that displays parentPath for each level.
  */
 const LevelComponent: React.FC<SduiComponentProps> = ({ nodeId, parentPath = [] }) => {
   const { childrenIds } = useSduiNodeSubscription({
@@ -39,8 +39,8 @@ const LevelComponent: React.FC<SduiComponentProps> = ({ nodeId, parentPath = [] 
 }
 
 /**
- * 레벨 컴포넌트 팩토리
- * useRenderNode hook을 사용하여 자식 노드들을 렌더링합니다.
+ * Level component factory.
+ * Renders child nodes using the useRenderNode hook.
  */
 const LevelComponentFactory: ComponentFactory = (id, parentPath) => {
   return <LevelComponent nodeId={id} parentPath={parentPath} />
@@ -50,7 +50,7 @@ describe('Parent Path Tracking', () => {
   describe('as is: document with 5 levels of nesting', () => {
     describe('when: rendering nested components', () => {
       it('to be: parentPath is correctly propagated through all 5 levels', () => {
-        // 5단계 깊이의 노드 트리 생성
+        // Create a node tree with 5 levels of depth
         const document = createTestDocument({
           root: {
             id: 'root',
@@ -97,35 +97,35 @@ describe('Parent Path Tracking', () => {
           />,
         )
 
-        // Root 레벨 확인 (parentPath가 없어야 함)
+        // Verify root level (parentPath should be empty)
         const rootElement = screen.getByTestId('level-root')
         expect(rootElement).toBeInTheDocument()
         expect(rootElement).toHaveAttribute('data-parent-path', JSON.stringify([]))
         expect(rootElement).toHaveAttribute('data-current-path', 'root')
         expect(screen.getByText('Parent Path: none')).toBeInTheDocument()
 
-        // Level 1 확인 (parentPath: ['root'])
+        // Verify level 1 (parentPath: ['root'])
         const level1Element = screen.getByTestId('level-level-1')
         expect(level1Element).toBeInTheDocument()
         expect(level1Element).toHaveAttribute('data-parent-path', JSON.stringify(['root']))
         expect(level1Element).toHaveAttribute('data-current-path', 'root > level-1')
         expect(screen.getByText('Parent Path: root')).toBeInTheDocument()
 
-        // Level 2 확인 (parentPath: ['root', 'level-1'])
+        // Verify level 2 (parentPath: ['root', 'level-1'])
         const level2Element = screen.getByTestId('level-level-2')
         expect(level2Element).toBeInTheDocument()
         expect(level2Element).toHaveAttribute('data-parent-path', JSON.stringify(['root', 'level-1']))
         expect(level2Element).toHaveAttribute('data-current-path', 'root > level-1 > level-2')
         expect(screen.getByText('Parent Path: root > level-1')).toBeInTheDocument()
 
-        // Level 3 확인 (parentPath: ['root', 'level-1', 'level-2'])
+        // Verify level 3 (parentPath: ['root', 'level-1', 'level-2'])
         const level3Element = screen.getByTestId('level-level-3')
         expect(level3Element).toBeInTheDocument()
         expect(level3Element).toHaveAttribute('data-parent-path', JSON.stringify(['root', 'level-1', 'level-2']))
         expect(level3Element).toHaveAttribute('data-current-path', 'root > level-1 > level-2 > level-3')
         expect(screen.getByText('Parent Path: root > level-1 > level-2')).toBeInTheDocument()
 
-        // Level 4 확인 (parentPath: ['root', 'level-1', 'level-2', 'level-3'])
+        // Verify level 4 (parentPath: ['root', 'level-1', 'level-2', 'level-3'])
         const level4Element = screen.getByTestId('level-level-4')
         expect(level4Element).toBeInTheDocument()
         expect(level4Element).toHaveAttribute(
@@ -135,7 +135,7 @@ describe('Parent Path Tracking', () => {
         expect(level4Element).toHaveAttribute('data-current-path', 'root > level-1 > level-2 > level-3 > level-4')
         expect(screen.getByText('Parent Path: root > level-1 > level-2 > level-3')).toBeInTheDocument()
 
-        // Level 5 확인 (parentPath: ['root', 'level-1', 'level-2', 'level-3', 'level-4'])
+        // Verify level 5 (parentPath: ['root', 'level-1', 'level-2', 'level-3', 'level-4'])
         const level5Element = screen.getByTestId('level-level-5')
         expect(level5Element).toBeInTheDocument()
         expect(level5Element).toHaveAttribute(
@@ -184,7 +184,7 @@ describe('Parent Path Tracking', () => {
           />,
         )
 
-        // 모든 형제 노드가 같은 parentPath를 받아야 함
+        // All sibling nodes should receive the same parentPath
         const sibling1 = screen.getByTestId('level-sibling-1')
         const sibling2 = screen.getByTestId('level-sibling-2')
         const sibling3 = screen.getByTestId('level-sibling-3')

--- a/packages/sdui-template/src/__tests__/scenario/subscription.test.tsx
+++ b/packages/sdui-template/src/__tests__/scenario/subscription.test.tsx
@@ -40,7 +40,7 @@ const SubscribedComponent: React.FC<{ nodeId: string; testPrefix?: string }> = (
 const ComponentWithUpdateButton: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const store = useSduiLayoutAction()
   const handleUpdate = () => {
-    // node-1만 업데이트
+    // Update only node-1
     store.updateNodeState('node-1', { value: 15 })
   }
 
@@ -93,12 +93,12 @@ describe('Subscription System', () => {
           },
         })
 
-        // SDUI renderer만 사용 (별도 컴포넌트 없음)
+        // Use only the SDUI renderer (no separate components)
         renderWithSduiLayout(
           document,
           {
             components: {
-              Container: defaultTestComponentFactory, // Container는 자식을 렌더링하는 기본 컴포넌트 사용
+              Container: defaultTestComponentFactory, // Use the default component to render children
               TestComponent: TestComponentFactory,
             },
           },
@@ -109,7 +109,7 @@ describe('Subscription System', () => {
         expect(screen.getByTestId('sdui-subscribed-node-2')).toBeInTheDocument()
         expect(screen.getByTestId('sdui-subscribed-node-3')).toBeInTheDocument()
 
-        // 초기 상태 확인
+        // Verify initial state
         const node1Initial = screen.getByTestId('sdui-subscribed-node-1')
         expect(node1Initial).toHaveTextContent('Value: 10')
         expect(node1Initial).toHaveTextContent('Render Count: 1')
@@ -122,7 +122,7 @@ describe('Subscription System', () => {
         expect(node3Initial).toHaveTextContent('Value: 30')
         expect(node3Initial).toHaveTextContent('Render Count: 1')
 
-        // 버튼 클릭하여 업데이트
+        // Click the button to update
         const updateButton = screen.getByTestId('update-button')
         updateButton.click()
 

--- a/packages/sdui-template/src/__tests__/scenario/sync-external-store.test.tsx
+++ b/packages/sdui-template/src/__tests__/scenario/sync-external-store.test.tsx
@@ -62,7 +62,7 @@ describe('useSyncExternalStore Tearing Prevention', () => {
 
           React.useEffect(() => {
             // Rapid updates to simulate concurrent rendering scenario
-            // 각 업데이트 사이에 충분한 간격을 두어 React가 처리할 수 있도록 함
+            // Leave enough time between updates so React can process them
             setTimeout(() => store.updateNodeState('node-1', { value: 20 }), 10)
             setTimeout(() => store.updateNodeState('node-1', { value: 30 }), 30)
             setTimeout(() => store.updateNodeState('node-1', { value: 40 }), 50)
@@ -87,7 +87,7 @@ describe('useSyncExternalStore Tearing Prevention', () => {
           <RapidUpdateTest />,
         )
 
-        // Wait for all updates to complete (마지막 업데이트가 50ms 후이므로 충분한 시간 대기)
+        // Wait for all updates to complete (last update is after 50ms, so wait long enough)
         await waitFor(
           () => {
             const comp1 = screen.getByTestId('test1-subscribed-node-1')
@@ -139,7 +139,7 @@ describe('useSyncExternalStore Tearing Prevention', () => {
             // Update state
             store.updateNodeState('node-1', { value: 50 })
 
-            // Immediately read via state (getSnapshot은 lastModified와 version만 반환)
+            // Immediately read via state (getSnapshot only returns lastModified and version)
             const { nodes } = store.state
             const node = nodes['node-1']
             setSnapshotValue((node?.state as any)?.value)
@@ -282,7 +282,7 @@ describe('useSyncExternalStore Tearing Prevention', () => {
           const store = useSduiLayoutAction()
 
           React.useEffect(() => {
-            // 각 업데이트 사이에 충분한 간격을 두어 React가 처리할 수 있도록 함
+            // Leave enough time between updates so React can process them
             setTimeout(() => {
               store.updateNodeState('node-1', { value: 15 })
             }, 20)
@@ -349,7 +349,7 @@ describe('useSyncExternalStore Tearing Prevention', () => {
           const [snapshotState, setSnapshotState] = React.useState<number | null>(null)
 
           React.useEffect(() => {
-            // getSnapshot은 lastModified와 version만 반환하므로 state에서 직접 가져옴
+            // getSnapshot only returns lastModified and version, so read directly from state
             const { nodes } = store.state
             const node = nodes['node-1']
             setSnapshotState((node?.state as any)?.value)
@@ -390,4 +390,3 @@ describe('useSyncExternalStore Tearing Prevention', () => {
     })
   })
 })
-

--- a/packages/sdui-template/src/__tests__/utils/dev-utils.tsx
+++ b/packages/sdui-template/src/__tests__/utils/dev-utils.tsx
@@ -17,10 +17,10 @@ import { SduiLayoutStore } from '../../store'
 import type { SduiLayoutStoreOptions } from '../../store/types'
 
 /**
- * 테스트용 기본 노드 컴포넌트 (자식 렌더링 포함)
+ * Default node component for tests (includes child rendering).
  *
- * 노드 정보를 표시하고 자식 노드를 렌더링합니다.
- * 테스트에서 기본 컴포넌트로 사용됩니다.
+ * Displays node info and renders child nodes.
+ * Used as the default component in tests.
  */
 export const TestDefaultNodeComponent: React.FC<SduiComponentProps> = ({ nodeId: id, parentPath = [] }) => {
   const { type, childrenIds } = useSduiNodeSubscription({
@@ -46,9 +46,9 @@ export const TestDefaultNodeComponent: React.FC<SduiComponentProps> = ({ nodeId:
 }
 
 /**
- * 테스트용 기본 컴포넌트 팩토리
+ * Default component factory for tests.
  *
- * 테스트에서 기본 컴포넌트로 사용되는 팩토리입니다.
+ * Factory used as the default component in tests.
  */
 export const defaultTestComponentFactory: ComponentFactory = (id, parentPath) => (
   <TestDefaultNodeComponent nodeId={id} parentPath={parentPath} />
@@ -64,12 +64,12 @@ export function createTestDocument(overrides?: Partial<SduiLayoutDocument>): Sdu
     children: [],
   }
 
-  // overrides가 있으면 병합 (state와 attributes는 normalize에서 자동 처리되므로 명시하지 않아도 됨)
+  // Merge overrides if provided (state and attributes are auto-handled by normalize)
   const mergedRoot = overrides?.root
     ? {
         ...defaultRoot,
         ...overrides.root,
-        // state와 attributes는 normalize에서 자동으로 {}로 설정되므로 명시하지 않아도 됨
+        // state and attributes default to {} in normalize, so no need to set explicitly
       }
     : defaultRoot
 
@@ -80,7 +80,7 @@ export function createTestDocument(overrides?: Partial<SduiLayoutDocument>): Sdu
       name: 'Test Document',
     },
     ...overrides,
-    root: mergedRoot, // root는 항상 병합된 결과 사용
+    root: mergedRoot, // Always use the merged root result
   }
 }
 

--- a/packages/sdui-template/src/components/DefaultNodeComponent.tsx
+++ b/packages/sdui-template/src/components/DefaultNodeComponent.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 /**
- * 기본 노드 컴포넌트
+ * Default node component.
  *
- * 노드 타입이 매핑되지 않았을 때 사용되는 기본 컴포넌트입니다.
- * 개발 환경에서 노드 정보를 표시합니다.
+ * Used when a node type is not mapped.
+ * Displays node information in the development environment.
  */
 
 import React from 'react'
@@ -13,10 +13,10 @@ import { useSduiNodeSubscription } from '../react-wrapper/hooks/useSduiNodeSubsc
 import type { SduiComponentProps } from './types'
 
 /**
- * 기본 노드 컴포넌트
+ * Default node component.
  *
- * 노드 타입이 매핑되지 않았을 때 사용되는 기본 컴포넌트입니다.
- * 개발 환경에서 노드 정보를 표시합니다.
+ * Used when a node type is not mapped.
+ * Displays node information in the development environment.
  */
 export const DefaultNodeComponent: React.FC<SduiComponentProps> = ({ nodeId: id, parentPath = [] }) => {
   const { type, childrenIds } = useSduiNodeSubscription({

--- a/packages/sdui-template/src/components/componentMap.tsx
+++ b/packages/sdui-template/src/components/componentMap.tsx
@@ -3,20 +3,20 @@
 /**
  * SDUI Component Map
  *
- * 노드 타입별 컴포넌트 매핑을 정의합니다.
- * Render Props Pattern: renderNode 함수를 상위에서 주입받아 자식을 렌더링합니다.
+ * Defines component mappings by node type.
+ * Render Props Pattern: inject renderNode from the parent to render children.
  *
  * @remarks
- * 기본 componentMap은 비어있습니다. Consumers는 components prop을 통해
- * 자신의 컴포넌트를 제공해야 합니다.
+ * The default componentMap is empty. Consumers must provide their components
+ * via the components prop.
  */
 
 import type { ComponentFactory } from './types'
 
 /**
- * 컴포넌트 맵
+ * Component map.
  *
- * 노드 타입별로 컴포넌트 팩토리를 매핑합니다.
- * 기본적으로 비어있으며, consumers가 components prop을 통해 제공합니다.
+ * Maps component factories by node type.
+ * Empty by default; consumers provide components via the components prop.
  */
 export const componentMap: Record<string, ComponentFactory> = {}

--- a/packages/sdui-template/src/components/defaultComponentFactory.tsx
+++ b/packages/sdui-template/src/components/defaultComponentFactory.tsx
@@ -1,8 +1,8 @@
 /**
- * 기본 컴포넌트 팩토리
+ * Default component factory.
  *
- * 노드 타입이 componentMap에 없을 때 사용되는 기본 팩토리입니다.
- * 노드 정보를 표시하고 자식을 렌더링합니다.
+ * Used when a node type is not present in the componentMap.
+ * Displays node info and renders children.
  */
 
 import React from 'react'
@@ -11,10 +11,10 @@ import { DefaultNodeComponent } from './DefaultNodeComponent'
 import type { ComponentFactory } from './types'
 
 /**
- * 기본 컴포넌트 팩토리
+ * Default component factory.
  *
- * 노드 타입이 componentMap에 없을 때 사용되는 기본 팩토리입니다.
- * 노드 정보를 표시하고 자식을 렌더링합니다.
+ * Used when a node type is not present in the componentMap.
+ * Displays node info and renders children.
  */
 export const defaultComponentFactory: ComponentFactory = (id, parentPath) => (
   <DefaultNodeComponent nodeId={id} parentPath={parentPath} />

--- a/packages/sdui-template/src/components/types.ts
+++ b/packages/sdui-template/src/components/types.ts
@@ -1,45 +1,45 @@
 /**
  * Server-Driven UI - Component System Types
  *
- * 컴포넌트 팩토리 및 렌더링 함수 타입 정의
+ * Component factory and render function type definitions
  */
 
 import type { ReactNode } from 'react'
 
 /**
- * 부모 노드 ID 경로 타입
+ * Parent node ID path type
  *
- * 디버깅을 위한 부모 노드 ID 경로입니다.
- * 예: ['root', 'container-1', 'button-1']
+ * Parent node ID path for debugging.
+ * Example: ['root', 'container-1', 'button-1']
  */
 export type ParentPath = string[]
 
 /**
- * SDUI 컴포넌트의 공통 Props 타입
+ * Common props type for SDUI components
  *
- * 모든 SDUI 컴포넌트가 공통으로 사용하는 props입니다.
- * ComponentFactory에서 컴포넌트로 전달할 때 사용합니다.
+ * Props shared across all SDUI components.
+ * Used when ComponentFactory passes props to components.
  */
 export interface SduiComponentProps {
-  /** 노드 ID */
+  /** Node ID */
   nodeId: string
-  /** 디버깅을 위한 부모 노드 ID 경로 */
+  /** Parent node ID path for debugging */
   parentPath?: ParentPath
 }
 
 /**
- * 자식 노드 렌더링 함수 타입 (Render Props)
+ * Child node rendering function type (Render Props)
  *
- * 상위에서 주입되어 자식 노드를 렌더링할 때 사용합니다.
- * parentPath는 디버깅을 위한 부모 노드 ID 경로입니다.
+ * Injected from the parent and used to render child nodes.
+ * parentPath is the parent node ID path for debugging.
  */
 export type RenderNodeFn = (childId: string, parentPath?: ParentPath) => ReactNode
 
 /**
- * 컴포넌트 팩토리 타입
+ * Component factory type
  *
- * id, parentPath를 받아서 컴포넌트를 렌더링합니다.
- * parentPath는 디버깅을 위한 부모 노드 ID 경로입니다 (예: ['root', 'container-1']).
- * 컴포넌트 내부에서 useRenderNode hook을 사용하여 자식 노드를 렌더링할 수 있습니다.
+ * Renders a component given id and parentPath.
+ * parentPath is the parent node ID path for debugging (e.g., ['root', 'container-1']).
+ * Components can render child nodes using the useRenderNode hook.
  */
 export type ComponentFactory = (id: string, parentPath?: ParentPath) => ReactNode

--- a/packages/sdui-template/src/react-wrapper/components/SduiLayoutRenderer.tsx
+++ b/packages/sdui-template/src/react-wrapper/components/SduiLayoutRenderer.tsx
@@ -3,8 +3,8 @@
 /**
  * SDUI Layout Renderer
  *
- * SDUI Layout Document를 받아서 전체 UI를 렌더링하는 최상위 컴포넌트입니다.
- * Render Props Pattern: renderNode 함수를 정의하고 하위 컴포넌트에 주입합니다.
+ * Top-level component that renders the entire UI from an SDUI Layout Document.
+ * Render Props Pattern: defines the renderNode function and injects it into child components.
  *
  * @param document - SDUI Layout Document (required)
  * @param components - Custom component map (optional, merged with defaults)
@@ -40,9 +40,9 @@ import { useRenderNode } from '../hooks'
 interface SduiLayoutRendererProps {
   /** SDUI Layout Document */
   document: SduiLayoutDocument
-  /** 커스텀 컴포넌트 맵 (componentMap에 추가될 컴포넌트들) */
+  /** Custom component map (components added to componentMap) */
   components?: Record<string, ComponentFactory>
-  /** 1회용 컴포넌트 오버라이드 설정 */
+  /** One-time component override settings */
   componentOverrides?: {
     byNodeId?: Record<string, ComponentFactory>
     byNodeType?: Record<string, ComponentFactory>
@@ -54,11 +54,11 @@ interface SduiLayoutRendererProps {
 }
 
 /**
- * SduiLayoutRenderer 내부 컴포넌트
+ * SduiLayoutRenderer internal component.
  *
- * useRenderNode hook을 사용하여 renderNode 함수를 생성하고,
- * 하위 컴포넌트에 주입합니다.
- * 각 컴포넌트는 이 함수를 통해 자식을 렌더링합니다.
+ * Uses the useRenderNode hook to create the renderNode function and
+ * injects it into child components.
+ * Each component renders its children through this function.
  */
 const SduiLayoutRendererInner = ({
   id,
@@ -67,8 +67,8 @@ const SduiLayoutRendererInner = ({
   id: string
   componentMap?: Record<string, ComponentFactory>
 }) => {
-  // renderNode 함수 생성 (Render Props Pattern)
-  // root 노드는 parentPath 없이 렌더링
+  // Create the renderNode function (Render Props Pattern)
+  // Render the root node without parentPath
   const { renderNode } = useRenderNode({ nodeId: id, componentMap: customComponentMap, parentPath: [] })
 
   return renderNode(id, [])
@@ -77,7 +77,7 @@ const SduiLayoutRendererInner = ({
 /**
  * SduiLayoutRenderer
  *
- * SDUI Layout Document를 렌더링하는 최상위 컴포넌트입니다.
+ * Top-level component that renders an SDUI Layout Document.
  */
 export const SduiLayoutRenderer: React.FC<SduiLayoutRendererProps> = ({
   document,
@@ -87,11 +87,11 @@ export const SduiLayoutRenderer: React.FC<SduiLayoutRendererProps> = ({
   onError,
 }) => {
   const storeRef = useRef<SduiLayoutStore | null>(null)
-  // Store 인스턴스 생성 및 문서 업데이트
-  // components와 componentOverrides는 한 번만 설정되므로 deps에 포함하지 않음
+  // Create store instance and update the document
+  // components and componentOverrides are set once, so they are excluded from deps
   const store = useMemo(() => {
     try {
-      // 문서 유효성 검사
+      // Document validation
       if (!document || !document.root) {
         throw new Error('Invalid document: missing root')
       }
@@ -100,7 +100,7 @@ export const SduiLayoutRenderer: React.FC<SduiLayoutRendererProps> = ({
       }
 
       const options: SduiLayoutStoreOptions = {
-        // 스프레드 연산자로 합침 (components → byNodeType → byNodeId 순서, ID 우선)
+        // Merge with spread (components → byNodeType → byNodeId order, ID takes priority)
         componentOverrides: {
           ...components,
           ...componentOverrides?.byNodeType,
@@ -136,7 +136,7 @@ export const SduiLayoutRenderer: React.FC<SduiLayoutRendererProps> = ({
     }
   }, [components])
 
-  // root.id가 없으면 렌더링하지 않음 (에러는 이미 onError로 전달됨)
+  // Do not render if root.id is missing (error already passed to onError)
   const rootId = document?.root?.id
   if (!rootId) {
     return null

--- a/packages/sdui-template/src/react-wrapper/context/SduiLayoutContext.tsx
+++ b/packages/sdui-template/src/react-wrapper/context/SduiLayoutContext.tsx
@@ -3,7 +3,7 @@
 /**
  * SDUI Layout Context
  *
- * Context API를 사용하여 SduiLayoutStore를 제공합니다.
+ * Provides SduiLayoutStore via the Context API.
  */
 
 import React, { createContext, useContext, useMemo } from 'react'
@@ -11,10 +11,10 @@ import React, { createContext, useContext, useMemo } from 'react'
 import type { SduiLayoutStore } from '../../store'
 
 /**
- * SduiLayoutContext 타입
+ * SduiLayoutContext type
  */
 interface SduiLayoutContextValue {
-  /** Store 인스턴스 */
+  /** Store instance */
   store: SduiLayoutStore
 }
 
@@ -27,16 +27,16 @@ const SduiLayoutContext = createContext<SduiLayoutContextValue | null>(null)
  * SduiLayoutProvider Props
  */
 interface SduiLayoutProviderProps {
-  /** Store 인스턴스 */
+  /** Store instance */
   store: SduiLayoutStore
-  /** 자식 컴포넌트 */
+  /** Child components */
   children: React.ReactNode
 }
 
 /**
  * SduiLayoutProvider
  *
- * Context를 통해 SduiLayoutStore를 제공합니다.
+ * Provides SduiLayoutStore via context.
  */
 export const SduiLayoutProvider: React.FC<SduiLayoutProviderProps> = ({ store, children }) => {
   const value = useMemo(
@@ -52,8 +52,8 @@ export const SduiLayoutProvider: React.FC<SduiLayoutProviderProps> = ({ store, c
 /**
  * useSduiLayoutContext
  *
- * Context에서 store를 가져옵니다.
- * Provider 외부에서 사용 시 에러를 throw합니다.
+ * Retrieves the store from context.
+ * Throws an error when used outside the provider.
  */
 export const useSduiLayoutContext = (): SduiLayoutContextValue => {
   const context = useContext(SduiLayoutContext)
@@ -64,5 +64,4 @@ export const useSduiLayoutContext = (): SduiLayoutContextValue => {
 
   return context
 }
-
 

--- a/packages/sdui-template/src/react-wrapper/context/index.ts
+++ b/packages/sdui-template/src/react-wrapper/context/index.ts
@@ -1,7 +1,7 @@
 /**
  * Server-Driven UI - React Context
  *
- * Context API 및 Provider export
+ * Export Context API and Provider
  */
 
 export * from './SduiLayoutContext'

--- a/packages/sdui-template/src/react-wrapper/hooks/useSduiLayoutAction.ts
+++ b/packages/sdui-template/src/react-wrapper/hooks/useSduiLayoutAction.ts
@@ -3,9 +3,9 @@
 /**
  * useSduiLayoutAction
  *
- * Store 인스턴스를 반환하여 액션을 호출할 수 있게 합니다.
+ * Returns the store instance so actions can be invoked.
  *
- * @returns Store 인스턴스
+ * @returns Store instance
  *
  * @example
  * ```tsx

--- a/packages/sdui-template/src/react-wrapper/hooks/useSduiNodeReference.ts
+++ b/packages/sdui-template/src/react-wrapper/hooks/useSduiNodeReference.ts
@@ -3,15 +3,15 @@
 /**
  * SDUI Node Reference Hook
  *
- * reference 필드를 통해 참조된 노드들의 정보를 쉽게 접근할 수 있게 하는 hook입니다.
- * 참조된 노드들의 변경사항도 자동으로 구독하여 리렌더링을 트리거합니다.
+ * Hook that provides easy access to nodes referenced via the reference field.
+ * Automatically subscribes to changes in referenced nodes to trigger re-renders.
  *
  * @description
- * - reference가 string이면 단일 노드, string[]이면 다중 노드 참조
- * - 참조된 노드들의 state, attributes 등을 배열과 Map으로 반환
- * - 참조된 노드들의 변경사항도 자동으로 구독
- * - ID로 직접 접근: referencedNodesMap[id]
- * - 순회: referencedNodes.forEach(...)
+ * - If reference is a string, it is a single node; string[] references multiple nodes
+ * - Returns referenced nodes' state, attributes, etc. as arrays and maps
+ * - Automatically subscribes to referenced node changes
+ * - Direct access by ID: referencedNodesMap[id]
+ * - Iterate: referencedNodes.forEach(...)
  */
 
 import React, { useMemo, useSyncExternalStore } from 'react'
@@ -23,53 +23,53 @@ import { useSduiLayoutAction } from './useSduiLayoutAction'
 import { useSduiNodeSubscription } from './useSduiNodeSubscription'
 
 /**
- * 참조된 노드 정보 타입
+ * Referenced node info type
  */
 export interface ReferencedNodeInfo {
-  /** 노드 ID */
+  /** Node ID */
   id: string
-  /** 노드 엔티티 */
+  /** Node entity */
   node: SduiLayoutNode | undefined
-  /** 노드 타입 */
+  /** Node type */
   type: string | undefined
-  /** 노드 상태 */
+  /** Node state */
   state: Record<string, unknown>
-  /** 노드 속성 */
+  /** Node attributes */
   attributes: Record<string, unknown> | undefined
-  /** 노드 존재 여부 */
+  /** Whether the node exists */
   exists: boolean
 }
 
 /**
- * useSduiNodeReference 파라미터 타입
+ * useSduiNodeReference parameter type
  */
 export interface UseSduiNodeReferenceParams<
   TSchema extends ZodSchema<Record<string, unknown>> = ZodSchema<Record<string, unknown>>,
 > {
-  /** 참조를 가진 노드 ID */
+  /** Node ID that holds the reference */
   nodeId: string
-  /** 참조된 노드의 state를 검증할 Zod 스키마 (선택적) */
+  /** Zod schema to validate referenced node state (optional) */
   schema?: TSchema
 }
 
 /**
- * 여러 노드 ID에 대해 구독 및 정보를 수집하는 헬퍼 hook
+ * Helper hook to subscribe to multiple node IDs and collect their info.
  *
- * useSyncExternalStore를 사용하여 모든 노드를 한 번에 구독합니다.
- * tearing 문제를 방지합니다.
+ * Uses useSyncExternalStore to subscribe to all nodes at once.
+ * Prevents tearing issues.
  *
- * @template TSchema - Zod 스키마 타입
- * @param nodeIds - 구독할 노드 ID 배열
- * @param schema - Zod 스키마 (선택적)
- * @returns 각 노드에 대한 구독 결과 배열
+ * @template TSchema - Zod schema type
+ * @param nodeIds - Array of node IDs to subscribe to
+ * @param schema - Zod schema (optional)
+ * @returns Array of subscription results for each node
  */
 function useMultipleNodeSubscriptions<
   TSchema extends ZodSchema<Record<string, unknown>> = ZodSchema<Record<string, unknown>>,
 >(nodeIds: string[], schema?: TSchema): Array<ReturnType<typeof useSduiNodeSubscription<TSchema>>> {
   const store = useSduiLayoutAction()
 
-  // 각 노드 ID별 lastModified 값 추출을 위한 캐시
-  // nodeIds와 lastModified 값이 같으면 같은 배열 참조 반환
+  // Cache for extracting lastModified values per node ID
+  // Return the same array reference when nodeIds and lastModified values are unchanged
   const lastModifiedCacheRef = React.useRef<{
     nodeIdsKey: string
     values: string[]
@@ -79,14 +79,14 @@ function useMultipleNodeSubscriptions<
     values: string[]
   } | null>(null)
 
-  // useSyncExternalStore를 사용하여 모든 노드 구독
-  // 각 노드의 lastModified 값만 추출하여 비교
+  // Subscribe to all nodes using useSyncExternalStore
+  // Compare only the lastModified values for each node
   const lastModifiedValues = useSyncExternalStore(
-    // subscribe 함수: 모든 노드와 version 변경 구독
+    // subscribe function: subscribe to all nodes and version changes
     (onStoreChange) => {
-      // 각 노드에 대한 구독
+      // Subscribe to each node
       const unsubscribes = nodeIds.map((nodeId) => store.subscribeNode(nodeId, onStoreChange))
-      // version 구독 (nodes 전체 변경 감지)
+      // Subscribe to version (detects full nodes changes)
       const unsubscribeVersion = store.subscribeVersion(onStoreChange)
 
       return () => {
@@ -94,13 +94,13 @@ function useMultipleNodeSubscriptions<
         unsubscribeVersion()
       }
     },
-    // getSnapshot: 구독한 노드들의 lastModified 값만 추출하여 반환
+    // getSnapshot: return only lastModified values for subscribed nodes
     () => {
       const lastModifiedSnapshot = store.getSnapshot()
       const values = nodeIds.map((id) => lastModifiedSnapshot[id] || 'none')
       const nodeIdsKey = nodeIds.join(',')
 
-      // 캐시 확인: nodeIds와 값이 같으면 같은 배열 참조 반환
+      // Cache check: return the same array reference when nodeIds and values match
       if (
         lastModifiedCacheRef.current &&
         lastModifiedCacheRef.current.nodeIdsKey === nodeIdsKey &&
@@ -110,15 +110,15 @@ function useMultipleNodeSubscriptions<
         return lastModifiedCacheRef.current.values
       }
 
-      // 새 배열 생성 및 캐시 업데이트
+      // Create a new array and update cache
       lastModifiedCacheRef.current = { nodeIdsKey, values }
       return values
     },
-    // getServerSnapshot: SSR용 (캐싱하여 무한 루프 방지)
+    // getServerSnapshot: for SSR (cache to prevent infinite loops)
     () => {
       const nodeIdsKey = nodeIds.join(',')
       
-      // 서버 스냅샷은 한 번만 계산하고 캐시하여 안정적인 참조 유지
+      // Compute the server snapshot once and cache it to keep a stable reference
       if (
         serverSnapshotCacheRef.current &&
         serverSnapshotCacheRef.current.nodeIdsKey === nodeIdsKey
@@ -133,11 +133,11 @@ function useMultipleNodeSubscriptions<
     },
   )
 
-  // lastModified 값들이 변경되면 리렌더링되므로, 이 시점에 store.state에서 직접 읽기
+  // When lastModified values change, re-render; read directly from store.state here
   const { nodes } = store.state
 
-  // 스키마 검증 및 결과 변환
-  // lastModified 값들을 문자열로 변환하여 의존성 배열에 사용
+  // Validate schema and transform results
+  // Convert lastModified values to a string for the dependency array
   const lastModifiedKeys = useMemo(() => lastModifiedValues.join(':'), [lastModifiedValues])
 
   return useMemo(() => {
@@ -173,25 +173,25 @@ function useMultipleNodeSubscriptions<
 }
 
 /**
- * reference 필드를 통해 참조된 노드들의 정보를 반환하는 hook
+ * Hook that returns information about nodes referenced via the reference field.
  *
- * @template TSchema - Zod 스키마 타입. 참조된 노드들의 state를 검증합니다.
- * @param params - 파라미터 객체
- *   - `nodeId`: 참조를 가진 노드 ID
- *   - `schema`: Zod 스키마 (선택적). 참조된 노드들의 state를 검증합니다.
- * @returns 참조된 노드 정보
- *   - `referencedNodes`: 참조된 노드 정보 배열 (순회용)
- *   - `referencedNodesMap`: 참조된 노드 정보 맵 (ID로 직접 접근용)
- *   - `reference`: 원본 reference 값 (string | string[] | undefined)
- *   - `hasReference`: reference가 있는지 여부 (boolean)
+ * @template TSchema - Zod schema type. Validates referenced nodes' state.
+ * @param params - Parameter object
+ *   - `nodeId`: Node ID that holds the reference
+ *   - `schema`: Zod schema (optional). Validates referenced nodes' state.
+ * @returns Referenced node info
+ *   - `referencedNodes`: Array of referenced node info (for iteration)
+ *   - `referencedNodesMap`: Map of referenced node info (direct access by ID)
+ *   - `reference`: Original reference value (string | string[] | undefined)
+ *   - `hasReference`: Whether a reference exists (boolean)
  *
  * @example
  * ```tsx
- * // ID로 직접 접근
+ * // Direct access by ID
  * const { referencedNodesMap } = useSduiNodeReference({ nodeId: 'source-node' })
  * const targetNode = referencedNodesMap['target-node-id']
  *
- * // 배열로 순회
+ * // Iterate over the array
  * const { referencedNodes } = useSduiNodeReference({
  *   nodeId: 'source-node',
  *   schema: cardStateSchema // optional
@@ -218,19 +218,19 @@ export function useSduiNodeReference<
 } {
   const { nodeId, schema } = params
 
-  // 현재 노드의 reference 가져오기
+  // Get the current node's reference
   const { reference } = useSduiNodeSubscription({ nodeId })
 
-  // 참조된 노드 ID 배열로 변환
+  // Convert referenced IDs to an array
   const referencedIds = useMemo(() => {
     if (!reference) return []
     return Array.isArray(reference) ? reference : [reference]
   }, [reference])
 
-  // 각 참조된 노드에 대해 구독 및 정보 수집 (헬퍼 함수 사용)
+  // Subscribe to each referenced node and collect info (using helper)
   const referencedSubscriptions = useMultipleNodeSubscriptions<TSchema>(referencedIds, schema)
 
-  // 참조된 노드들의 정보를 ReferencedNodeInfo 형태로 변환하고 Map도 함께 생성
+  // Convert referenced node info into ReferencedNodeInfo and build the map
   const { referencedNodes, referencedNodesMap } = useMemo(() => {
     const nodes = referencedSubscriptions.map((sub, index) => {
       const refId = referencedIds[index]
@@ -246,7 +246,7 @@ export function useSduiNodeReference<
       ReferencedNodeInfo & { state: TSchema extends ZodSchema<any> ? z.infer<TSchema> : Record<string, unknown> }
     >
 
-    // ID로 바로 접근할 수 있는 Map 생성 (한 번의 순회로 처리)
+    // Build a map for direct access by ID (single pass)
     const map: Record<
       string,
       ReferencedNodeInfo & { state: TSchema extends ZodSchema<any> ? z.infer<TSchema> : Record<string, unknown> }

--- a/packages/sdui-template/src/react-wrapper/hooks/useSduiNodeSubscription.ts
+++ b/packages/sdui-template/src/react-wrapper/hooks/useSduiNodeSubscription.ts
@@ -3,15 +3,15 @@
 /**
  * SDUI Node Subscription Hook
  *
- * useSyncExternalStore 기반 구독 시스템을 사용하여 특정 노드의 변경을 감지하고
- * 리렌더링을 트리거합니다. tearing 문제를 방지하기 위해 내부적으로
- * useSduiNodeSubscriptionSync를 사용합니다.
+ * Uses a useSyncExternalStore-based subscription system to detect changes
+ * for a specific node and trigger re-renders. To prevent tearing,
+ * it uses useSduiNodeSubscriptionSync internally.
  *
  * @description
- * - useSyncExternalStore를 사용하여 React 18+ concurrent rendering에서 tearing 방지
- * - nodes, variables: version 구독으로 변경 감지
- * - layoutStates/layoutAttributes: 노드별 구독으로 변경 감지
- * - 타임스탬프 기반 스냅샷 비교로 효율적인 리렌더링
+ * - Prevents tearing in React 18+ concurrent rendering with useSyncExternalStore
+ * - nodes, variables: detect changes by version subscription
+ * - layoutStates/layoutAttributes: detect changes by per-node subscription
+ * - Efficient re-rendering via timestamp-based snapshot comparison
  */
 
 import type { z, ZodSchema } from 'zod'
@@ -20,37 +20,37 @@ import type { SduiLayoutNode } from '../../schema'
 import { useSduiNodeSubscriptionSync } from './useSduiNodeSubscriptionSync'
 
 /**
- * useSduiNodeSubscription 파라미터 타입
+ * useSduiNodeSubscription parameter types
  */
 export interface UseSduiNodeSubscriptionParams<
   TSchema extends ZodSchema<Record<string, unknown>> = ZodSchema<Record<string, unknown>>,
 > {
-  /** 구독할 노드 ID */
+  /** Node ID to subscribe to */
   nodeId: string
-  /** Zod 스키마 (선택적). state를 검증하고, 실패 시 에러를 throw합니다. 성공 시 state는 스키마에서 추론된 타입으로 보장됩니다. */
+  /** Zod schema (optional). Validates state and throws on failure. On success, state is inferred from the schema. */
   schema?: TSchema
 }
 
 /**
- * 특정 노드 ID를 구독하고 변경 시 리렌더링을 트리거합니다.
+ * Subscribe to a specific node ID and trigger re-renders on changes.
  *
- * 내부적으로 useSyncExternalStore를 사용하여 tearing 문제를 방지합니다.
+ * Internally uses useSyncExternalStore to prevent tearing.
  *
- * - nodes, variables: version 구독으로 변경 감지
- * - layoutStates: 노드별 구독으로 변경 감지
+ * - nodes, variables: detect changes by version subscription
+ * - layoutStates: detect changes by per-node subscription
  *
- * @template TSchema - Zod 스키마 타입. 스키마에서 타입을 추론합니다.
- * @param params - 구독 파라미터 객체
- *   - `nodeId`: 구독할 노드 ID
- *   - `schema`: Zod 스키마 (선택적). state를 검증하고, 실패 시 에러를 throw합니다. 성공 시 state는 스키마에서 추론된 타입으로 보장됩니다.
- * @returns 노드 정보 객체
- *   - `node`: 노드 엔티티 (SduiLayoutNode | undefined)
- *   - `type`: 노드 타입 (string | undefined)
- *   - `state`: 레이아웃 상태 (스키마가 제공되면 z.infer<TSchema>, 아니면 Record<string, unknown>)
- *   - `childrenIds`: 자식 노드 ID 배열 (string[])
- *   - `attributes`: 노드 속성 (Record<string, unknown> | undefined)
- *   - `reference`: 노드 참조 (string | string[] | undefined)
- *   - `exists`: 노드 존재 여부 (boolean)
+ * @template TSchema - Zod schema type. Infers types from the schema.
+ * @param params - Subscription parameter object
+ *   - `nodeId`: Node ID to subscribe to
+ *   - `schema`: Zod schema (optional). Validates state and throws on failure. On success, state is inferred from the schema.
+ * @returns Node info object
+ *   - `node`: Node entity (SduiLayoutNode | undefined)
+ *   - `type`: Node type (string | undefined)
+ *   - `state`: Layout state (z.infer<TSchema> if schema is provided, otherwise Record<string, unknown>)
+ *   - `childrenIds`: Array of child node IDs (string[])
+ *   - `attributes`: Node attributes (Record<string, unknown> | undefined)
+ *   - `reference`: Node reference (string | string[] | undefined)
+ *   - `exists`: Whether the node exists (boolean)
  *
  * @example
  * ```tsx
@@ -73,6 +73,6 @@ export function useSduiNodeSubscription<
   reference: string | string[] | undefined
   exists: boolean
 } {
-  // useSyncExternalStore 기반 구독으로 위임
+  // Delegate to the useSyncExternalStore-based subscription
   return useSduiNodeSubscriptionSync(params)
 }

--- a/packages/sdui-template/src/react-wrapper/hooks/useSduiNodeSubscriptionSync.ts
+++ b/packages/sdui-template/src/react-wrapper/hooks/useSduiNodeSubscriptionSync.ts
@@ -3,14 +3,14 @@
 /**
  * SDUI Node Subscription Sync Hook
  *
- * useSyncExternalStore를 사용하여 tearing 문제를 방지하는 구독 시스템입니다.
- * 타임스탬프 기반 스냅샷 비교를 통해 효율적인 리렌더링을 제공합니다.
+ * Subscription system that prevents tearing using useSyncExternalStore.
+ * Provides efficient re-rendering via timestamp-based snapshot comparison.
  *
  * @description
- * - useSyncExternalStore를 사용하여 React 18+ concurrent rendering에서 tearing 방지
- * - lastModified 타임스탬프를 기반으로 스냅샷 비교
- * - nodes, variables: version 구독으로 변경 감지
- * - layoutStates/layoutAttributes: 노드별 구독으로 변경 감지
+ * - Prevents tearing in React 18+ concurrent rendering with useSyncExternalStore
+ * - Snapshot comparison based on lastModified timestamps
+ * - nodes, variables: detect changes by version subscription
+ * - layoutStates/layoutAttributes: detect changes by per-node subscription
  */
 
 import React, { useSyncExternalStore } from 'react'
@@ -21,33 +21,33 @@ import type { SduiLayoutStore } from '../../store/SduiLayoutStore'
 import { useSduiLayoutAction } from './useSduiLayoutAction'
 
 /**
- * useSduiNodeSubscriptionSync 파라미터 타입
+ * useSduiNodeSubscriptionSync parameter types
  */
 export interface UseSduiNodeSubscriptionSyncParams<
   TSchema extends ZodSchema<Record<string, unknown>> = ZodSchema<Record<string, unknown>>,
 > {
-  /** 구독할 노드 ID */
+  /** Node ID to subscribe to */
   nodeId: string
-  /** Zod 스키마 (선택적). state를 검증하고, 실패 시 에러를 throw합니다. 성공 시 state는 스키마에서 추론된 타입으로 보장됩니다. */
+  /** Zod schema (optional). Validates state and throws on failure. On success, state is inferred from the schema. */
   schema?: TSchema
 }
 
 /**
- * 특정 노드 ID를 구독하고 변경 시 리렌더링을 트리거합니다.
- * useSyncExternalStore를 사용하여 tearing 문제를 방지합니다.
+ * Subscribe to a specific node ID and trigger re-renders on changes.
+ * Prevents tearing by using useSyncExternalStore.
  *
- * @template TSchema - Zod 스키마 타입. 스키마에서 타입을 추론합니다.
- * @param params - 구독 파라미터 객체
- *   - `nodeId`: 구독할 노드 ID
- *   - `schema`: Zod 스키마 (선택적). state를 검증하고, 실패 시 에러를 throw합니다. 성공 시 state는 스키마에서 추론된 타입으로 보장됩니다.
- * @returns 노드 정보 객체
- *   - `node`: 노드 엔티티 (SduiLayoutNode | undefined)
- *   - `type`: 노드 타입 (string | undefined)
- *   - `state`: 레이아웃 상태 (스키마가 제공되면 z.infer<TSchema>, 아니면 Record<string, unknown>)
- *   - `childrenIds`: 자식 노드 ID 배열 (string[])
- *   - `attributes`: 노드 속성 (Record<string, unknown> | undefined)
- *   - `reference`: 노드 참조 (string | string[] | undefined)
- *   - `exists`: 노드 존재 여부 (boolean)
+ * @template TSchema - Zod schema type. Infers types from the schema.
+ * @param params - Subscription parameter object
+ *   - `nodeId`: Node ID to subscribe to
+ *   - `schema`: Zod schema (optional). Validates state and throws on failure. On success, state is inferred from the schema.
+ * @returns Node info object
+ *   - `node`: Node entity (SduiLayoutNode | undefined)
+ *   - `type`: Node type (string | undefined)
+ *   - `state`: Layout state (z.infer<TSchema> if schema is provided, otherwise Record<string, unknown>)
+ *   - `childrenIds`: Array of child node IDs (string[])
+ *   - `attributes`: Node attributes (Record<string, unknown> | undefined)
+ *   - `reference`: Node reference (string | string[] | undefined)
+ *   - `exists`: Whether the node exists (boolean)
  *
  * @example
  * ```tsx
@@ -73,31 +73,31 @@ export function useSduiNodeSubscriptionSync<
   const { nodeId, schema } = params
   const store = useSduiLayoutAction()
 
-  // useSyncExternalStore를 사용하여 구독 및 스냅샷 선택
-  // 해당 노드의 lastModified 값만 비교하여 효율적인 변경 감지
+  // Subscribe and select snapshots using useSyncExternalStore
+  // Efficiently detect changes by comparing only the node's lastModified value
   const lastModifiedCacheRef = React.useRef<string | null>(null)
   const serverSnapshotCacheRef = React.useRef<string | null>(null)
 
   const lastModifiedValue = useSyncExternalStore<string>(
-    // subscribe 함수: 노드 변경 및 version 변경 모두 구독
+    // subscribe function: subscribe to both node and version changes
     (onStoreChange) => {
-      // 노드별 구독 (layoutStates/layoutAttributes 변경 감지)
+      // Per-node subscription (detect layoutStates/layoutAttributes changes)
       const unsubscribeNode = store.subscribeNode(nodeId, onStoreChange)
-      // version 구독 (nodes, rootId, variables 변경 감지)
+      // Version subscription (detect nodes, rootId, variables changes)
       const unsubscribeVersion = store.subscribeVersion(onStoreChange)
 
-      // 두 구독 모두 해제하는 함수 반환
+      // Return a function that unsubscribes from both
       return () => {
         unsubscribeNode()
         unsubscribeVersion()
       }
     },
-    // getSnapshot 함수: 해당 노드의 lastModified 값만 반환 (비교용)
+    // getSnapshot: return only the node's lastModified value (for comparison)
     () => {
       const lastModifiedSnapshot = store.getSnapshot()
       const value = lastModifiedSnapshot[nodeId] || 'none'
 
-      // 값이 같으면 같은 문자열 참조 반환 (캐싱)
+      // If the value matches, return the same string reference (caching)
       if (lastModifiedCacheRef.current === value) {
         return lastModifiedCacheRef.current
       }
@@ -105,9 +105,9 @@ export function useSduiNodeSubscriptionSync<
       lastModifiedCacheRef.current = value
       return value
     },
-    // getServerSnapshot 함수: SSR 시 스냅샷 반환 (캐싱하여 무한 루프 방지)
+    // getServerSnapshot: return a snapshot for SSR (cache to prevent infinite loops)
     () => {
-      // 서버 스냅샷은 한 번만 계산하고 캐시하여 안정적인 참조 유지
+      // Compute the server snapshot once and cache it to keep a stable reference
       if (serverSnapshotCacheRef.current === null) {
         const lastModifiedSnapshot = store.getServerSnapshot()
         serverSnapshotCacheRef.current = lastModifiedSnapshot[nodeId] || 'none'
@@ -116,7 +116,7 @@ export function useSduiNodeSubscriptionSync<
     },
   )
 
-  // lastModified 객체 참조가 변경되면 리렌더링되므로, 이 시점에 store.state에서 직접 읽기
+  // When the lastModified reference changes, re-render; read directly from store.state here
   const { nodes } = store.state
   const node = nodes[nodeId]
   const childrenIds = (node as any)?.childrenIds || []
@@ -124,17 +124,17 @@ export function useSduiNodeSubscriptionSync<
   const attributes = node?.attributes
   const reference = node?.reference
 
-  // 스키마 검증
+  // Schema validation
   let validatedState: Record<string, unknown>
 
   if (!schema) {
-    // 스키마가 없으면 rawState 사용 (없으면 빈 객체)
+    // If no schema, use rawState (or an empty object if missing)
     validatedState = rawState || {}
   } else if (!node || !rawState) {
-    // 노드가 없으면 스키마 검증을 건너뛰고 빈 객체 반환
+    // If the node is missing, skip validation and return an empty object
     validatedState = {}
   } else {
-    // 스키마 검증 수행
+    // Perform schema validation
     const result = schema.safeParse(rawState)
     if (!result.success) {
       throw new Error(`State validation failed for node "${nodeId}": ${result.error.message}`)

--- a/packages/sdui-template/src/schema/base.ts
+++ b/packages/sdui-template/src/schema/base.ts
@@ -1,48 +1,48 @@
 /**
- * Server-Driven UI - 기본 스키마
+ * Server-Driven UI - Base schema
  *
- * SDUI의 기본 노드와 문서 구조를 정의합니다.
+ * Defines the base node and document structure for SDUI.
  */
 
-// ==================== 기본 SDUI 노드 ====================
+// ==================== Base SDUI Node ====================
 
 /**
- * SDUI 노드 기본 인터페이스
+ * Base interface for SDUI nodes.
  *
- * 재귀적 구조를 가지며, 각 노드는 id, type, state, children을 가집니다.
+ * Has a recursive structure where each node has id, type, state, and children.
  */
 export interface SduiNode {
-  /** 노드 고유 식별자 */
+  /** Node unique identifier */
   id: string
 
-  /** 컴포넌트 타입 */
+  /** Component type */
   type: string
 
-  /** 상태 (모든 설정값 및 UI 상태) */
+  /** State (all configuration values and UI state) */
   state?: Record<string, unknown>
 
-  /** 외형 스타일 속성 (순수 CSS 스타일만) */
+  /** Visual style attributes (pure CSS styles only) */
   attributes?: Record<string, unknown>
 
-  /** 다른 노드 참조 (단일 또는 다중 참조) */
+  /** References to other nodes (single or multiple) */
   reference?: string | string[]
 
-  /** 자식 노드 배열 (재귀 구조) */
+  /** Child node array (recursive structure) */
   children?: SduiNode[]
 }
 
-// ==================== 기본 SDUI 문서 ====================
+// ==================== Base SDUI Document ====================
 
 /**
- * SDUI 문서 기본 인터페이스
+ * Base interface for SDUI documents.
  *
- * 서버에서 내려주는 전체 UI 구조를 담는 루트 문서입니다.
+ * Root document containing the entire UI structure delivered from the server.
  */
 export interface SduiDocument {
-  /** 스키마 버전 */
+  /** Schema version */
   version: string
 
-  /** 문서 메타데이터 */
+  /** Document metadata */
   metadata?: {
     id?: string
     name?: string
@@ -52,9 +52,9 @@ export interface SduiDocument {
     author?: string
   }
 
-  /** 루트 노드 */
+  /** Root node */
   root: SduiNode
 
-  /** 전역 변수 */
+  /** Global variables */
   variables?: Record<string, unknown>
 }

--- a/packages/sdui-template/src/schema/document.ts
+++ b/packages/sdui-template/src/schema/document.ts
@@ -1,22 +1,21 @@
 /**
- * Server-Driven UI - Layout 전용 문서
+ * Server-Driven UI - Layout-specific document
  *
- * Layout 시스템을 위한 문서 타입 정의
+ * Document type definitions for the layout system.
  */
 
 import type { SduiDocument } from './base'
 import type { SduiLayoutNode } from './node'
 
 /**
- * Layout 전용 문서
+ * Layout-specific document.
  *
- * SduiDocument를 상속받아 root를 SduiLayoutNode로 구체화합니다.
+ * Extends SduiDocument and specializes root to SduiLayoutNode.
  */
 export interface SduiLayoutDocument extends SduiDocument {
-  /** 루트 노드 (Layout 전용 노드) */
+  /** Root node (layout-specific node) */
   root: SduiLayoutNode
 }
-
 
 
 

--- a/packages/sdui-template/src/schema/index.ts
+++ b/packages/sdui-template/src/schema/index.ts
@@ -1,14 +1,14 @@
 /**
  * Server-Driven UI - Schema
  *
- * SDUI 스키마 타입들을 export합니다.
+ * Export SDUI schema types.
  */
 
-// 기본 스키마
+// Base schema
 export type * from './base'
 
-// 노드 스키마
+// Node schema
 export type * from './node'
 
-// 문서 스키마
+// Document schema
 export type * from './document'

--- a/packages/sdui-template/src/schema/node.ts
+++ b/packages/sdui-template/src/schema/node.ts
@@ -1,29 +1,29 @@
 /**
- * Server-Driven UI - Layout 전용 노드
+ * Server-Driven UI - Layout-specific node
  *
- * Layout 시스템을 위한 노드 타입 정의
+ * Node type definitions for the layout system.
  */
 
 import type { SduiNode } from './base'
 
 /**
- * Layout 전용 노드
+ * Layout-specific node.
  *
- * SduiNode를 상속받아 state를 LayoutState로 구체화합니다.
+ * Extends SduiNode and specializes state for layout.
  */
 export interface SduiLayoutNode extends SduiNode {
-  /** 컴포넌트 타입 */
+  /** Component type */
   type: string
 
-  /** 레이아웃 상태 */
+  /** Layout state */
   state?: Record<string, unknown>
 
-  /** 자식 노드 배열 (재귀 구조) */
+  /** Child node array (recursive structure) */
   children?: SduiLayoutNode[]
 
-  /** 자식 노드 ID 배열 (normalize 시 추가됨, 원본 문서에는 없음) */
+  /** Child node ID array (added during normalization, not in the original document) */
   childrenIds?: string[]
 
-  /** 부모 노드 ID (normalize 시 추가됨, 루트 노드는 undefined, 원본 문서에는 없음) */
+  /** Parent node ID (added during normalization, root is undefined, not in the original document) */
   parentId?: string
 }

--- a/packages/sdui-template/src/store/index.ts
+++ b/packages/sdui-template/src/store/index.ts
@@ -1,7 +1,7 @@
 /**
  * Server-Driven UI - Store
  *
- * Store 클래스 및 타입 export
+ * Export store classes and types
  */
 
 export * from './errors'

--- a/packages/sdui-template/src/store/managers/DocumentManager.ts
+++ b/packages/sdui-template/src/store/managers/DocumentManager.ts
@@ -2,7 +2,7 @@
 /**
  * DocumentManager
  *
- * 문서 캐싱, 복원, 직렬화를 관리합니다.
+ * Manages document caching, restoration, and serialization.
  */
 
 import { cloneDeep } from 'lodash-es'
@@ -14,76 +14,76 @@ import type { LayoutStateRepository } from './LayoutStateRepository'
 /**
  * DocumentManager
  *
- * 문서 캐싱, 복원, 직렬화를 관리합니다.
+ * Manages document caching, restoration, and serialization.
  */
 export class DocumentManager {
-  /** 문서 메타데이터 */
+  /** Document metadata */
   private _metadata?: SduiLayoutDocument['metadata']
 
-  /** 캐시된 문서 */
+  /** Cached documents */
   private _cached: Record<string, SduiLayoutDocument> = {}
 
-  /** 원본 문서 캐시 (편집 취소용) */
+  /** Original document cache (for undo) */
   private _originalCached: Record<string, SduiLayoutDocument> = {}
 
   /**
-   * 문서를 캐시합니다.
+   * Cache a document.
    *
-   * @param document - 캐시할 문서
+   * @param document - Document to cache
    */
   cacheDocument(document: SduiLayoutDocument): void {
     const documentId = document.metadata?.id || document.root.id
     this._cached[documentId] = document
 
-    // 원본 캐시가 없으면 저장
+    // Save the original if it does not exist
     if (!this._originalCached[documentId]) {
       this._originalCached[documentId] = cloneDeep(document)
     }
   }
 
   /**
-   * 메타데이터를 설정합니다.
+   * Set metadata.
    *
-   * @param metadata - 메타데이터
+   * @param metadata - Metadata
    */
   setMetadata(metadata?: SduiLayoutDocument['metadata']): void {
     this._metadata = metadata
   }
 
   /**
-   * 메타데이터를 반환합니다.
+   * Return metadata.
    *
-   * @returns 메타데이터 또는 undefined
+   * @returns Metadata or undefined
    */
   getMetadata(): SduiLayoutDocument['metadata'] | undefined {
     return this._metadata
   }
 
   /**
-   * 원본 문서를 반환합니다.
+   * Return the original document.
    *
-   * @param documentId - 문서 ID
-   * @returns 원본 문서 또는 undefined
+   * @param documentId - Document ID
+   * @returns Original document or undefined
    */
   getOriginalDocument(documentId: string): SduiLayoutDocument | undefined {
     return this._originalCached[documentId]
   }
 
   /**
-   * 문서 ID를 가져옵니다.
+   * Get the document ID.
    *
-   * @param rootId - 루트 노드 ID (fallback)
-   * @returns 문서 ID 또는 undefined
+   * @param rootId - Root node ID (fallback)
+   * @returns Document ID or undefined
    */
   getDocumentId(rootId?: string): string | undefined {
     return this._metadata?.id || rootId
   }
 
   /**
-   * 현재 상태를 문서로 변환합니다.
+   * Convert the current state into a document.
    *
-   * @param repository - 상태 저장소
-   * @returns 복원된 문서 또는 null
+   * @param repository - State repository
+   * @returns Restored document or null
    */
   getDocument(repository: LayoutStateRepository): SduiLayoutDocument | null {
     const rootId = repository.getRootId()
@@ -103,7 +103,7 @@ export class DocumentManager {
   }
 
   /**
-   * 캐시를 초기화합니다.
+   * Clear the cache.
    */
   clearCache(): void {
     this._cached = {}
@@ -111,7 +111,7 @@ export class DocumentManager {
   }
 
   /**
-   * 상태를 초기화합니다.
+   * Reset the state.
    */
   reset(): void {
     this._metadata = undefined

--- a/packages/sdui-template/src/store/managers/SubscriptionManager.ts
+++ b/packages/sdui-template/src/store/managers/SubscriptionManager.ts
@@ -2,28 +2,28 @@
 /**
  * SubscriptionManager
  *
- * Observer Pattern을 구현하여 구독 시스템을 관리합니다.
- * ID별 구독자와 version 구독자를 관리합니다.
+ * Manages the subscription system using the Observer pattern.
+ * Manages per-ID subscribers and version subscribers.
  */
 
 /**
  * SubscriptionManager
  *
- * 구독 시스템을 독립적으로 관리하는 클래스입니다.
+ * A class that manages the subscription system independently.
  */
 export class SubscriptionManager {
-  /** ID별 구독자 관리 (layoutStates/layoutAttributes 변경 감지용) */
+  /** Per-ID subscriber management (for detecting layoutStates/layoutAttributes changes) */
   private _nodeListeners = new Map<string, Set<() => void>>()
 
-  /** version 구독자 관리 (nodes, rootId, variables 변경 감지용) */
+  /** Version subscriber management (for detecting nodes, rootId, variables changes) */
   private _versionListeners = new Set<() => void>()
 
   /**
-   * 특정 노드 ID를 구독합니다.
+   * Subscribe to a specific node ID.
    *
-   * @param nodeId - 구독할 노드 ID
-   * @param callback - 변경 시 호출될 콜백 (forceRender)
-   * @returns 구독 해제 함수
+   * @param nodeId - Node ID to subscribe to
+   * @param callback - Callback invoked on changes (forceRender)
+   * @returns Unsubscribe function
    */
   subscribeNode(nodeId: string, callback: () => void): () => void {
     if (!this._nodeListeners.has(nodeId)) {
@@ -33,7 +33,7 @@ export class SubscriptionManager {
 
     return () => {
       this._nodeListeners.get(nodeId)?.delete(callback)
-      // 구독자가 없으면 Map에서 제거 (메모리 정리)
+      // Remove from the map when no subscribers remain (memory cleanup)
       if (this._nodeListeners.get(nodeId)?.size === 0) {
         this._nodeListeners.delete(nodeId)
       }
@@ -41,10 +41,10 @@ export class SubscriptionManager {
   }
 
   /**
-   * version을 구독합니다. (nodes, rootId, variables 변경 감지용)
+   * Subscribe to version changes. (for detecting nodes, rootId, variables changes)
    *
-   * @param callback - 변경 시 호출될 콜백 (forceRender)
-   * @returns 구독 해제 함수
+   * @param callback - Callback invoked on changes (forceRender)
+   * @returns Unsubscribe function
    */
   subscribeVersion(callback: () => void): () => void {
     this._versionListeners.add(callback)
@@ -54,27 +54,27 @@ export class SubscriptionManager {
   }
 
   /**
-   * 특정 노드의 구독자에게 변경을 알립니다.
+   * Notify subscribers of a specific node.
    *
-   * @param nodeId - 변경된 노드 ID
+   * @param nodeId - Updated node ID
    */
   notifyNode(nodeId: string): void {
     this._nodeListeners.get(nodeId)?.forEach((callback) => callback())
   }
 
   /**
-   * 여러 노드의 구독자에게 변경을 알립니다.
+   * Notify subscribers of multiple nodes.
    *
-   * @param nodeIds - 변경된 노드 ID 배열
+   * @param nodeIds - Array of updated node IDs
    */
   notifyNodes(nodeIds: string[]): void {
-    // 중복 제거 후 notify
+    // Remove duplicates before notifying
     const uniqueIds = [...new Set(nodeIds)]
     uniqueIds.forEach((nodeId) => this.notifyNode(nodeId))
   }
 
   /**
-   * version 구독자에게 변경을 알립니다.
+   * Notify version subscribers of changes.
    */
   notifyVersion(): void {
     this._versionListeners.forEach((callback) => callback())

--- a/packages/sdui-template/src/store/managers/VariablesManager.ts
+++ b/packages/sdui-template/src/store/managers/VariablesManager.ts
@@ -2,7 +2,7 @@
 /**
  * VariablesManager
  *
- * 전역 변수 관리를 담당합니다.
+ * Handles global variable management.
  */
 
 import { cloneDeep } from 'lodash-es'
@@ -13,7 +13,7 @@ import type { SubscriptionManager } from './SubscriptionManager'
 /**
  * VariablesManager
  *
- * 전역 변수 관리를 담당합니다.
+ * Handles global variable management.
  */
 export class VariablesManager {
   constructor(
@@ -23,13 +23,13 @@ export class VariablesManager {
   {}
 
   /**
-   * 전역 변수를 업데이트합니다.
-   * 깊은 복사로 새 객체를 생성하여 version을 증가시킵니다.
+   * Update global variables.
+   * Increase the version by creating a new object via deep copy.
    *
-   * @param variables - 새로운 전역 변수 객체
+   * @param variables - New global variables object
    */
   updateVariables(variables: Record<string, unknown>): void {
-    // 깊은 복사로 새 객체 생성 → version 증가 → 전체 리렌더
+    // Create a new object via deep copy → increment version → full re-render
     this.repository.updateVariables(cloneDeep(variables))
     this.repository.setEdited(true)
     this.repository.incrementVersion()
@@ -37,14 +37,14 @@ export class VariablesManager {
   }
 
   /**
-   * 개별 전역 변수를 업데이트합니다.
-   * 깊은 복사로 새 객체를 생성하여 version을 증가시킵니다.
+   * Update an individual global variable.
+   * Increase the version by creating a new object via deep copy.
    *
-   * @param key - 변수 키
-   * @param value - 변수 값
+   * @param key - Variable key
+   * @param value - Variable value
    */
   updateVariable(key: string, value: unknown): void {
-    // 깊은 복사로 새 객체 생성 → version 증가 → 전체 리렌더
+    // Create a new object via deep copy → increment version → full re-render
     const current = this.repository.state.variables
     this.repository.updateVariables({
       ...cloneDeep(current),
@@ -56,9 +56,9 @@ export class VariablesManager {
   }
 
   /**
-   * 전역 변수를 삭제합니다.
+   * Delete a global variable.
    *
-   * @param key - 삭제할 변수 키
+   * @param key - Variable key to delete
    */
   deleteVariable(key: string): void {
     const newVariables = cloneDeep(this.repository.state.variables)
@@ -69,7 +69,6 @@ export class VariablesManager {
     this.subscriptionManager.notifyVersion()
   }
 }
-
 
 
 

--- a/packages/sdui-template/src/store/managers/index.ts
+++ b/packages/sdui-template/src/store/managers/index.ts
@@ -1,14 +1,13 @@
 /**
  * Server-Driven UI - Store Managers
  *
- * Store를 구성하는 매니저 클래스들
+ * Manager classes that compose the store
  */
 
 export * from "./DocumentManager";
 export * from "./LayoutStateRepository";
 export * from "./SubscriptionManager";
 export * from "./VariablesManager";
-
 
 
 

--- a/packages/sdui-template/src/store/types.ts
+++ b/packages/sdui-template/src/store/types.ts
@@ -1,7 +1,7 @@
 /**
  * Server-Driven UI - Store Types
  *
- * Store 상태 및 옵션 타입 정의
+ * Store state and option type definitions
  */
 
 import type { ReactNode } from 'react'
@@ -10,55 +10,55 @@ import type { ParentPath } from '../components/types'
 import type { SduiLayoutNode } from '../schema'
 
 /**
- * 자식 노드 렌더링 함수 타입 (Render Props)
+ * Child node rendering function type (Render Props)
  *
- * 상위에서 주입되어 자식 노드를 렌더링할 때 사용합니다.
- * parentPath는 디버깅을 위한 부모 노드 ID 경로입니다.
+ * Injected from the parent and used to render child nodes.
+ * parentPath is the parent node ID path for debugging.
  */
 export type RenderNodeFn = (childId: string, parentPath?: ParentPath) => ReactNode
 
 /**
- * 컴포넌트 팩토리 타입
+ * Component factory type
  *
- * id, parentPath를 받아서 컴포넌트를 렌더링합니다.
- * parentPath는 디버깅을 위한 부모 노드 ID 경로입니다 (예: ['root', 'container-1']).
- * 컴포넌트 내부에서 useRenderNode hook을 사용하여 자식 노드를 렌더링할 수 있습니다.
+ * Renders a component given id and parentPath.
+ * parentPath is the parent node ID path for debugging (e.g., ['root', 'container-1']).
+ * Components can render child nodes using the useRenderNode hook.
  */
 export type ComponentFactory = (id: string, parentPath?: ParentPath) => ReactNode
 
 /**
- * Store 상태
+ * Store state
  *
- * nodes, rootId, variables 등은 일반 변수로 관리하고
- * version을 구독하여 변경을 감지합니다.
+ * nodes, rootId, variables, etc. are stored as regular variables,
+ * and changes are detected by subscribing to version.
  */
 export interface SduiLayoutStoreState {
-  /** 전체 리렌더 트리거용 버전 */
+  /** Version for triggering full re-renders */
   version: number
 
-  /** 루트 노드 ID (트리 구조 변경 시 리렌더 필요) */
+  /** Root node ID (re-render needed when the tree structure changes) */
   rootId?: string
 
-  /** 노드 엔티티 (id → node) - 컴포넌트 구조 정의 */
+  /** Node entities (id → node) - defines the component structure */
   nodes: Record<string, SduiLayoutNode>
 
-  /** 선택된 노드 ID */
+  /** Selected node ID */
   selectedNodeId?: string
 
-  /** 레이아웃 편집 상태 */
+  /** Layout edit state */
   isEdited?: boolean
 
-  /** 전역 변수 (깊은 복사로 리렌더 트리거) */
+  /** Global variables (deep copy triggers re-render) */
   variables: Record<string, unknown>
 
-  /** 노드별 마지막 수정 시간 (nodeId → ISO timestamp) */
+  /** Last modified time per node (nodeId → ISO timestamp) */
   lastModified: Record<string, string>
 }
 
 /**
- * SduiLayoutStore 생성 옵션
+ * SduiLayoutStore creation options
  */
 export interface SduiLayoutStoreOptions {
-  /** 컴포넌트 오버라이드 맵 (ID 우선, 없으면 타입으로 조회) */
+  /** Component override map (prefer ID, fall back to type) */
   componentOverrides?: Record<string, ComponentFactory>
 }

--- a/packages/sdui-template/src/utils/normalize/denormalize.ts
+++ b/packages/sdui-template/src/utils/normalize/denormalize.ts
@@ -1,31 +1,31 @@
 /**
  * SDUI Layout Denormalize
  *
- * Normalized entities에서 문서를 복원합니다.
+ * Restores a document from normalized entities.
  */
 
 import type { SduiLayoutDocument, SduiLayoutNode } from '../../schema'
 import type { NormalizedSduiEntities } from './types'
 
 /**
- * Normalized entities에서 노드를 denormalize
+ * Denormalize a node from normalized entities.
  *
- * @param nodeId - 복원할 노드 ID
- * @param entities - normalize된 entities
- * @returns 복원된 노드
+ * @param nodeId - Node ID to restore
+ * @param entities - Normalized entities
+ * @returns Restored node
  */
 export function denormalizeSduiNode(nodeId: string, entities: NormalizedSduiEntities): SduiLayoutNode | null {
   const node = entities.nodes?.[nodeId]
   if (!node) return null
 
-  // children을 재귀적으로 복원
-  // children 정보는 별도로 저장되어 있지 않으므로, entities.nodes에서 찾아야 함
-  // 실제로는 노드 트리를 순회하면서 children을 찾아야 하지만,
-  // 여기서는 간단하게 처리하기 위해 노드에 childrenIds를 저장하는 방식 사용
+  // Recursively restore children
+  // Since children info is not stored separately, look it up in entities.nodes
+  // Ideally traverse the node tree to find children,
+  // but here we use childrenIds stored on nodes for simplicity
   const childrenIds: string[] = []
 
-  // entities.nodes를 순회하여 현재 노드를 parent로 가진 노드 찾기
-  // 또는 노드에 childrenIds 정보가 있다면 사용
+  // Find nodes whose parent is the current node by scanning entities.nodes
+  // Or use childrenIds if present on the node
   if ((node as any).childrenIds) {
     childrenIds.push(...(node as any).childrenIds)
   }
@@ -37,23 +37,23 @@ export function denormalizeSduiNode(nodeId: string, entities: NormalizedSduiEnti
   return {
     id: node.id,
     type: node.type,
-    // state가 없으면 빈 객체로 자동 설정
+    // Default to an empty object when state is missing
     state: node.state || {},
-    // attributes가 없으면 빈 객체로 자동 설정
+    // Default to an empty object when attributes are missing
     attributes: node.attributes || {},
-    // reference는 그대로 전달
+    // Pass reference through as-is
     ...(node.reference !== undefined && { reference: node.reference }),
     ...(children.length > 0 && { children }),
   }
 }
 
 /**
- * Normalized entities에서 전체 문서를 denormalize
+ * Denormalize a full document from normalized entities.
  *
- * @param rootId - 루트 노드 ID
- * @param entities - normalize된 entities
- * @param metadata - 문서 메타데이터 (선택적)
- * @returns 복원된 문서
+ * @param rootId - Root node ID
+ * @param entities - Normalized entities
+ * @param metadata - Document metadata (optional)
+ * @returns Restored document
  */
 export function denormalizeSduiLayout(
   rootId: string,

--- a/packages/sdui-template/src/utils/normalize/types.ts
+++ b/packages/sdui-template/src/utils/normalize/types.ts
@@ -1,17 +1,17 @@
 /**
  * Server-Driven UI - Normalized Entities Types
  *
- * Normalize된 엔티티 구조 정의
+ * Normalized entity structure definitions
  */
 
 import type { SduiLayoutNode } from '../../schema'
 
 /**
- * Normalize된 엔티티 구조
+ * Normalized entity structure
  *
- * id를 키로 사용하여 조회 가능한 형태로 변환됩니다.
+ * Converted into a lookup-friendly shape using id as the key.
  */
 export interface NormalizedSduiEntities {
-  /** 노드 엔티티 (id → SduiLayoutNode, state와 attributes 포함) */
+  /** Node entities (id → SduiLayoutNode, includes state and attributes) */
   nodes?: Record<string, SduiLayoutNode>
 }

--- a/packages/sdui-template/src/utils/parentPath.ts
+++ b/packages/sdui-template/src/utils/parentPath.ts
@@ -1,20 +1,20 @@
 /**
  * Parent Path Utilities
  *
- * 부모 노드 ID 경로를 다루는 유틸리티 함수들
+ * Utility functions for working with parent node ID paths.
  */
 
 import type { ParentPath } from '../components/types'
 
 /**
- * ParentPath를 문자열로 변환하는 헬퍼 함수
+ * Helper function to convert ParentPath to a string.
  *
- * 디버깅을 위해 경로를 읽기 쉬운 문자열 형식으로 변환합니다.
- * 예: ['root', 'container-1', 'button-1'] → 'root > container-1 > button-1'
+ * Converts a path into a readable string for debugging.
+ * Example: ['root', 'container-1', 'button-1'] → 'root > container-1 > button-1'
  *
- * @param path - 부모 노드 ID 경로
- * @param separator - 구분자 (기본값: ' > ')
- * @returns 경로 문자열
+ * @param path - Parent node ID path
+ * @param separator - Separator (default: ' > ')
+ * @returns Path string
  *
  * @example
  * ```tsx
@@ -27,14 +27,14 @@ export function formatParentPath(path: ParentPath, separator: string = ' > '): s
 }
 
 /**
- * parentPath와 nodeId를 받아 현재 경로 배열을 생성하는 헬퍼 함수
+ * Helper function to build the current path array from parentPath and nodeId.
  *
- * renderNode에 전달할 수 있는 ParentPath 배열을 생성합니다.
- * 예: buildCurrentPathArray(['root', 'container-1'], 'button-1') → ['root', 'container-1', 'button-1']
+ * Creates a ParentPath array that can be passed to renderNode.
+ * Example: buildCurrentPathArray(['root', 'container-1'], 'button-1') → ['root', 'container-1', 'button-1']
  *
- * @param parentPath - 부모 노드 ID 경로
- * @param nodeId - 현재 노드 ID
- * @returns 현재 노드까지의 경로 배열 (ParentPath)
+ * @param parentPath - Parent node ID path
+ * @param nodeId - Current node ID
+ * @returns Path array to the current node (ParentPath)
  *
  * @example
  * ```tsx
@@ -47,15 +47,15 @@ export function buildCurrentPathArray(parentPath: ParentPath, nodeId: string): P
 }
 
 /**
- * parentPath와 nodeId를 받아 현재 경로 문자열을 생성하는 헬퍼 함수
+ * Helper function to build the current path string from parentPath and nodeId.
  *
- * 디버깅을 위해 현재 노드까지의 전체 경로를 읽기 쉬운 문자열 형식으로 변환합니다.
- * 예: buildCurrentPath(['root', 'container-1'], 'button-1') → 'root > container-1 > button-1'
+ * Converts the full path to the current node into a readable string for debugging.
+ * Example: buildCurrentPath(['root', 'container-1'], 'button-1') → 'root > container-1 > button-1'
  *
- * @param parentPath - 부모 노드 ID 경로
- * @param nodeId - 현재 노드 ID
- * @param separator - 구분자 (기본값: ' > ')
- * @returns 현재 노드까지의 경로 문자열
+ * @param parentPath - Parent node ID path
+ * @param nodeId - Current node ID
+ * @param separator - Separator (default: ' > ')
+ * @returns Path string to the current node
  *
  * @example
  * ```tsx

--- a/packages/ssr-testing/app/components/componentMap.tsx
+++ b/packages/ssr-testing/app/components/componentMap.tsx
@@ -5,15 +5,14 @@ import { GridLayoutFactory } from './GridLayout'
 import { ToggleFactory } from './Toggle'
 
 /**
- * 컴포넌트 맵
+ * Component map.
  *
- * 노드 타입별로 컴포넌트 팩토리를 매핑합니다.
+ * Maps component factories by node type.
  */
 export const componentMap: Record<string, ComponentFactory> = {
   GridLayout: GridLayoutFactory,
   Toggle: ToggleFactory,
 }
-
 
 
 

--- a/packages/ssr-testing/app/page-render.spec.ts
+++ b/packages/ssr-testing/app/page-render.spec.ts
@@ -1,22 +1,22 @@
 import { expect,test } from '@playwright/test'
 
 /**
- * 페이지 렌더링 테스트
+ * Page render tests.
  *
- * SDUI Template SSR Testing 페이지가 올바르게 렌더링되는지 확인합니다.
+ * Verifies that the SDUI Template SSR Testing page renders correctly.
  */
 test.describe('페이지 렌더링', () => {
   test('메인 페이지가 올바르게 로드되고 렌더링된다', async ({ page }) => {
     await page.goto('/')
 
-    // 페이지 타이틀 확인
+    // Verify the page title
     await expect(page).toHaveTitle(/Create Next App/)
 
-    // 메인 헤딩 확인
+    // Verify the main heading
     const heading = page.getByRole('heading', { name: 'SDUI Template SSR Testing' })
     await expect(heading).toBeVisible()
 
-    // 설명 텍스트 확인
+    // Verify the description text
     const description = page.getByText('Next.js App Router를 사용한 Server-Driven UI 테스트 페이지입니다.')
     await expect(description).toBeVisible()
   })
@@ -24,14 +24,14 @@ test.describe('페이지 렌더링', () => {
   test('SDUI 레이아웃 컴포넌트들이 올바르게 렌더링된다', async ({ page }) => {
     await page.goto('/')
 
-    // 페이지가 완전히 로드될 때까지 대기
+    // Wait until the page fully loads
     await page.waitForLoadState('networkidle')
 
-    // GridLayout 컨테이너 확인
+    // Verify the GridLayout container
     const layoutContainer = page.locator('[data-testid="grid-layout"]').first()
     await expect(layoutContainer).toBeVisible({ timeout: 10000 })
 
-    // Toggle 컴포넌트들이 렌더링되는지 확인 (aria-label로 확인)
+    // Verify the Toggle components render (by aria-label)
     const toggle1 = page.getByRole('switch', { name: '알림 받기' })
     const toggle2 = page.getByRole('switch', { name: '다크 모드' })
     const toggle3 = page.getByRole('switch', { name: '자동 저장' })
@@ -40,7 +40,7 @@ test.describe('페이지 렌더링', () => {
     await expect(toggle2).toBeVisible({ timeout: 10000 })
     await expect(toggle3).toBeVisible({ timeout: 10000 })
 
-    // Toggle 버튼들이 렌더링되는지 확인 (data-node-id 사용)
+    // Verify the Toggle buttons render (using data-node-id)
     const toggle1Button = page.locator('[data-node-id="toggle-1"]')
     const toggle2Button = page.locator('[data-node-id="toggle-2"]')
     const toggle3Button = page.locator('[data-node-id="toggle-3"]')
@@ -54,17 +54,17 @@ test.describe('페이지 렌더링', () => {
     await page.goto('/')
     await page.waitForLoadState('networkidle')
 
-    // 첫 번째 토글: isChecked=false (aria-checked로 확인 - Radix Switch 사용)
+    // First toggle: isChecked=false (check aria-checked - Radix Switch)
     const toggle1 = page.locator('[data-node-id="toggle-1"]')
     await expect(toggle1).toBeVisible({ timeout: 10000 })
     await expect(toggle1).toHaveAttribute('aria-checked', 'false')
 
-    // 두 번째 토글: isChecked=true
+    // Second toggle: isChecked=true
     const toggle2 = page.locator('[data-node-id="toggle-2"]')
     await expect(toggle2).toBeVisible({ timeout: 10000 })
     await expect(toggle2).toHaveAttribute('aria-checked', 'true')
 
-    // 세 번째 토글: isChecked=false
+    // Third toggle: isChecked=false
     const toggle3 = page.locator('[data-node-id="toggle-3"]')
     await expect(toggle3).toBeVisible({ timeout: 10000 })
     await expect(toggle3).toHaveAttribute('aria-checked', 'false')
@@ -76,31 +76,31 @@ test.describe('페이지 렌더링', () => {
 
     const toggle1 = page.locator('[data-node-id="toggle-1"]')
 
-    // 초기 상태 확인
+    // Verify initial state
     await expect(toggle1).toBeVisible({ timeout: 10000 })
     await expect(toggle1).toHaveAttribute('aria-checked', 'false')
 
-    // 클릭하여 상태 변경
+    // Click to change state
     await toggle1.click()
-    // 상태 변경이 반영될 때까지 잠시 대기
+    // Briefly wait for the state change to apply
     await page.waitForTimeout(100)
     await expect(toggle1).toHaveAttribute('aria-checked', 'true')
 
-    // 다시 클릭하여 원래 상태로 복귀
+    // Click again to return to the original state
     await toggle1.click()
     await page.waitForTimeout(100)
     await expect(toggle1).toHaveAttribute('aria-checked', 'false')
   })
 
   test('페이지가 반응형으로 렌더링된다', async ({ page }) => {
-    // 모바일 뷰포트
+    // Mobile viewport
     await page.setViewportSize({ width: 375, height: 667 })
     await page.goto('/')
 
     const heading = page.getByRole('heading', { name: 'SDUI Template SSR Testing' })
     await expect(heading).toBeVisible()
 
-    // 데스크톱 뷰포트
+    // Desktop viewport
     await page.setViewportSize({ width: 1920, height: 1080 })
     await expect(heading).toBeVisible()
   })
@@ -120,10 +120,10 @@ test.describe('페이지 렌더링', () => {
 
     await page.goto('/')
 
-    // 기본 렌더링 확인
+    // Verify basic rendering
     await expect(page.getByRole('heading', { name: 'SDUI Template SSR Testing' })).toBeVisible()
 
-    // 에러가 없는지 확인 (SDUI Layout Error는 예상된 에러이므로 제외)
+    // Verify there are no errors (exclude expected SDUI Layout Error)
     const unexpectedErrors = errors.filter((error) => !error.includes('SDUI Layout Error'))
 
     expect(unexpectedErrors).toHaveLength(0)

--- a/packages/ssr-testing/app/page.tsx
+++ b/packages/ssr-testing/app/page.tsx
@@ -6,9 +6,9 @@ import { SduiLayoutRenderer } from '@lodado/sdui-template'
 import { componentMap } from './components/componentMap'
 
 /**
- * 예제 SDUI 문서
+ * Example SDUI document.
  *
- * 간단한 그리드 레이아웃과 토글 컴포넌트를 포함한 예제입니다.
+ * This example includes a simple grid layout and toggle components.
  */
 const exampleDocument: SduiLayoutDocument = {
   version: '1.0.0',

--- a/packages/ssr-testing/next.config.ts
+++ b/packages/ssr-testing/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  reactStrictMode: false, // 개발 모드 이중 렌더링 비활성화 (테스트용)
+  reactStrictMode: false, // Disable double rendering in dev mode (for testing)
 };
 
 export default nextConfig;

--- a/packages/ssr-testing/playwright.config.ts
+++ b/packages/ssr-testing/playwright.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
 /**
- * Playwright 설정 파일
+ * Playwright configuration file.
  *
- * Next.js 앱의 E2E 테스트를 위한 설정입니다.
+ * This is the configuration for E2E tests of the Next.js app.
  */
 export default defineConfig({
   testDir: './',
@@ -41,4 +41,3 @@ export default defineConfig({
     timeout: 120 * 1000,
   },
 });
-


### PR DESCRIPTION
### Motivation

- Standardize codebase documentation by translating in-source comments from Korean to English for wider team readability and external consumption. 
- Make examples and JSDoc consistent across packages (template, components, design files, tests, and utils).

### Description

- Translated and reworded comments and JSDoc across the monorepo including configs, packages, store, hooks, schema, utilities, components, and tests (many files under `packages/sdui-template`, `packages/sdui-template-component`, `packages/sdui-design-files`, and `packages/ssr-testing`).
- Converted key inline examples and README-style comments in components (e.g., `List`, `Card`, `Icon`, `Button`, `DefaultNodeComponent`) and test helpers to English for clarity.
- Updated comments in store and hooks for clearer API/behavior descriptions (e.g., `SduiLayoutStore`, subscription managers, normalization utilities, `useRenderNode`, `useSduiNodeReference`, `useSduiNodeSubscription*`).
- Updated several config and tooling comment lines (eslint, rollup, jest, Playwright config, layout CSS) to English and adjusted small phrasing in tests to use English descriptions.

### Testing

- Ran `pnpm lint` as part of the pre-commit checks; it produced warnings and errors and the run failed due to `turbo/no-undeclared-env-vars` errors related to `CI` usage in `packages/ssr-testing/playwright.config.ts` (linter output included other warnings about extraneous-dependencies and minor rule issues). (failure)
- No unit or E2E test suites were executed as part of this change beyond the lint run reported above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69815d6dc68c832ea2553d29b42078c8)